### PR TITLE
Fix LVcode.py flake8 warnings; refactor VICodePtrs_LVxx classes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+per-file-ignores =
+    # Don't insist on blank lines in LVmisc.py (E302: expected 2 blank lines, found 1)
+    pylabview/LVmisc.py: E302
+    # Ignore tabs before '=' in tables (E221/E223: multiple spaces/tab before operator)
+    pylabview/LVcode.py: E223, E221

--- a/pylabview/LVcode.py
+++ b/pylabview/LVcode.py
@@ -11,210 +11,146 @@
 # For a copy, see <https://opensource.org/licenses/MIT>.
 
 
-from pylabview.LVheap import ENUM_TAGS
+from pylabview.LVheap import ENUM_TAGS, Extend_ENUM_TAGS_Meta
+
 
 class VICodePtrs_LV5(ENUM_TAGS):
     """ List of VI Code Pointers from LV5
 
     These callbacks can be set from InitCodePtrsProc within VI compiled code.
     """
-    GoProc		= 0
-    RetryProc	= 1
-    ResumeProc	= 2
-    ResetProc	= 3
-    DisposeProc	= 4
-    InitProc	= 5
-    LoadProc	= 6
-    SaveProc	= 7
-    ErrorStopProc = 8
-    ConstantProc = 9
-    RngChkProc	= 10
-    DCODfltProc	= 11
+    GoProc		    = 0
+    RetryProc	    = 1
+    ResumeProc	    = 2
+    ResetProc	    = 3
+    DisposeProc	    = 4
+    InitProc	    = 5
+    LoadProc	    = 6
+    SaveProc	    = 7
+    ErrorStopProc   = 8
+    ConstantProc    = 9
+    RngChkProc	    = 10
+    DCODfltProc	    = 11
     SetAllDfltsProc	= 12
-    DCOCopyProc	= 13
+    DCOCopyProc	    = 13
     DCOCopyToOpProc	= 14
     DCOCopyFrOpProc	= 15
-    RunCode		= 16
+    RunCode		    = 16
     InitCodePtrsProc = 17
     PrxyCallerInitCPProc = 18
-    ReInitProc	= 19
-    CRoutine	= 20
+    ReInitProc	    = 19
+    CRoutine	    = 20
 
 
-class VICodePtrs_LV6(ENUM_TAGS):
+class VICodePtrs_LV6(metaclass=Extend_ENUM_TAGS_Meta):
     """ List of VI Code Pointers from LV6 before LV6.1
 
     These callbacks can be set from InitCodePtrsProc within VI compiled code.
     Since LV6.1 this no longer applies as one of the callbacks was renamed.
     """
-    CRoutine		= 0
-    RetryProc		= 1
-    ResumeProc		= 2
-    ResetProc		= 3
-    DisposeProc		= 4
-    InitProc		= 5
-    LoadProc		= 6
-    SaveProc		= 7
-    ErrorStopProc	= 8
-    ConstantProc	= 9
-    RngChkProc		= 10
-    DCODefaultProc	= 11
-    SetAllDefaultProc = 12
-    DCOCopyProc		= 13
-    DCOCopyToOpProc = 14
-    DCOCopyFrOpProc = 15
-    RunProc			= 16
-    InitCodePtrsProc = 17
-    ReInitProc		= 18
-    GoProc			= 19
+    P = VICodePtrs_LV5  # Short parent alias
+    _EXTENDS_ = P
+    _DROP_ = (P.DCODfltProc, P.SetAllDfltsProc, P.RunCode, P.PrxyCallerInitCPProc,)
+
+    CRoutine        = 0                     # was 20 before
+    DCODefaultProc  = P.DCODfltProc         # = 11
+    SetAllDefaultProc = P.SetAllDfltsProc   # = 12
+    RunProc         = P.RunCode             # = 16
+    ReInitProc      = 18                    # was 19 before
+    GoProc          = 19                    # was 0 before
+
+    # Clean up the alias P
+    del P
 
 
-class VICodePtrs_LV7(ENUM_TAGS):
+class VICodePtrs_LV7(metaclass=Extend_ENUM_TAGS_Meta):
     """ List of VI Code Pointers from LV6.1-LV7
 
     These callbacks can be set from InitCodePtrsProc within VI compiled code.
     """
-    CRoutine		= 0
-    RetryProc		= 1
-    ResumeProc		= 2
-    ResetProc		= 3
-    DisposeProc		= 4
-    InitProc		= 5
-    LoadProc		= 6
-    SaveProc		= 7
-    ErrorStopProc	= 8
-    ConstantProc	= 9
-    RngChkProc		= 10
-    DCODefaultProc	= 11
-    SetAllDefaultProc = 12
-    DCOCopyProc		= 13
-    DCOCopyToOpProc = 14
-    DCOCopyFrOpProc = 15
-    RunProc			= 16
-    InitCodePtrsProc = 17
-    ReserveUnReserveProc = 18
-    GoProc			= 19
+    _EXTENDS_ = VICodePtrs_LV6
+    _DROP_ = (VICodePtrs_LV6.ReInitProc,)
+
+    ReserveUnReserveProc = VICodePtrs_LV6.ReInitProc  # = 18
 
 
-class VICodePtrs_LV8(ENUM_TAGS):
+class VICodePtrs_LV8(metaclass=Extend_ENUM_TAGS_Meta):
     """ List of VI Code Pointers from LV8-LV11
 
     These callbacks can be set from InitCodePtrsProc within VI compiled code.
     """
-    CRoutine		= 0
-    RetryProc		= 1
-    ResumeProc		= 2
-    ResetProc		= 3
-    DisposeProc		= 4
-    InitProc		= 5
-    LoadProc		= 6
-    SaveProc		= 7
-    ErrorStopProc	= 8
-    ConstantProc	= 9
-    CompareProc		= 10
-    DCODefaultProc	= 11
-    SetAllDefaultProc = 12
-    DCOCopyProc		= 13
-    DCOCopyToOpProc = 14
-    DCOCopyFrOpProc = 15
-    RunProc			= 16 # Calls the method received in parameter
-    InitCodePtrsProc = 17
-    ReserveUnReserveProc = 18
-    GoProc			= 19
-    AcquireDSProc	= 20 # The 4 entries added in LV10
-    ReleaseDSProc	= 21
-    AcquireDSStaticProc	= 22
-    ReleaseDSStaticProc	= 23
+    _EXTENDS_ = VICodePtrs_LV7
+    _DROP_ = (VICodePtrs_LV7.RngChkProc,)
+
+    CompareProc         = VICodePtrs_LV7.RngChkProc  # = 10
+
+    # New entries added in LV10
+    AcquireDSProc       = 20
+    ReleaseDSProc       = 21
+    AcquireDSStaticProc = 22
+    ReleaseDSStaticProc = 23
 
 
-class VICodePtrs_LV12(ENUM_TAGS):
+class VICodePtrs_LV12(metaclass=Extend_ENUM_TAGS_Meta):
     """ List of VI Code Pointers from LV12
 
     These callbacks can be set from InitCodePtrsProc within VI compiled code.
     Pointers are either 32-bit or 64-bit, depending on architecture.
     """
-    CRoutine		= 0
-    RetryProc		= 1
-    ResumeProc		= 2
-    ResetProc		= 3
-    DisposeProc		= 4
-    InitProc		= 5
-    LoadProc		= 6
-    SaveProc		= 7
-    ErrorStopProc	= 8
-    ConstantProc	= 9
-    CompareProc		= 10
-    DCODefaultProc	= 11
-    SetAllDefaultProc = 12
-    DCOCopyProc		= 13
-    DCOCopyToOpProc = 14
-    DCOCopyFrOpProc = 15
-    RunCodeProc		= 16 # Calls the method received in parameter
-    InitCodePtrsProc = 17
-    ReserveUnReserveProc = 18
-    GoProc			= 19
-    DSTMNeededProc	= 20
-    GetDataSpaceSizeProc = 21
-    InflateDataSpaceProc = 22
-    DeflateDataSpaceProc = 23
-    ShrinkDataSpaceProc = 24
-    UnflattenDefaultsProc = 25
-    CopyDefaultsProc = 26
-    CodeDebugProc	= 27
-    CodeErrHandlingProc = 28
+    P = VICodePtrs_LV8
+    _EXTENDS_ = P
+    _DROP_ = (P.RunProc, P.AcquireDSProc, P.ReleaseDSProc, P.AcquireDSStaticProc, P.ReleaseDSStaticProc,)
+
+    RunCodeProc             = P.RunProc  # = 16
+
+    # New entries added in LV12
+    DSTMNeededProc          = 20
+    GetDataSpaceSizeProc    = 21
+    InflateDataSpaceProc    = 22
+    DeflateDataSpaceProc    = 23
+    ShrinkDataSpaceProc     = 24
+    UnflattenDefaultsProc   = 25
+    CopyDefaultsProc        = 26
+    CodeDebugProc           = 27
+    CodeErrHandlingProc     = 28
+
+    del P
 
 
-class VICodePtrs_LV13(ENUM_TAGS):
+class VICodePtrs_LV13(metaclass=Extend_ENUM_TAGS_Meta):
     """ List of VI Code Pointers from LV13-LV20
 
     These callbacks can be set from InitCodePtrsProc within VI compiled code.
     Pointers are either 32-bit or 64-bit, depending on architecture.
     """
-    CRoutine		= 0
-    RetryProc		= 1
-    ResumeProc		= 2
-    ResetProc		= 3
-    DisposeProc		= 4
-    InitProc		= 5
-    LoadProc		= 6
-    SaveProc		= 7
-    ErrorStopProc	= 8
-    ConstantProc	= 9
-    CompareProc		= 10
-    DCODefaultProc	= 11
-    SetAllDefaultProc = 12
-    DCOCopyProc		= 13
-    DCOCopyToOpProc = 14
-    DCOCopyFrOpProc = 15
-    ReserveUnReserveProc = 16
-    GoProc			= 17
-    DSTMNeeded		= 18
-    GetDataSpaceSizeProc = 19
-    InflateDataSpaceProc = 20
-    DeflateDataSpaceProc = 21
-    ShrinkDataSpaceProc = 22
-    UnflattenDefaultsProc= 23
-    CopyDefaultsProc	= 24
-    CodeDebugProc	= 25
-    CodeErrHandlingProc = 26
-    CopyConvertProcs = 27
-    InitCodePtrsProc = 28
-    nRunProcs		= 29
-    RunProc			= 30
-    RunProc2		= 31
-    RunProc3		= 32
-    RunProc4		= 33
-    RunProc5		= 34
-    RunProc6		= 35
-    RunProc7		= 36
-    RunProc8		= 37
-    RunProc9		= 38
-    RunProc10		= 39
-    RunProc11		= 40
-    RunProc12		= 41
-    RunProc13		= 42
-    RunProc14		= 43
-    RunProc15		= 44
+    P = VICodePtrs_LV12
+    _EXTENDS_ = P
+    _DROP_ = (P.RunCodeProc, P.DSTMNeededProc,)
+
+    # LV12 entries 18 to 28 shift down by 2 positions
+    ReserveUnReserveProc    = P.ReserveUnReserveProc.value - 2      # = 16
+    GoProc                  = P.GoProc.value - 2                    # = 17
+    DSTMNeeded              = P.DSTMNeededProc.value - 2            # = 18
+    GetDataSpaceSizeProc    = P.GetDataSpaceSizeProc.value - 2      # = 19
+    InflateDataSpaceProc    = P.InflateDataSpaceProc.value - 2      # = 20
+    DeflateDataSpaceProc    = P.DeflateDataSpaceProc.value - 2      # = 21
+    ShrinkDataSpaceProc     = P.ShrinkDataSpaceProc.value - 2       # = 22
+    UnflattenDefaultsProc   = P.UnflattenDefaultsProc.value - 2     # = 23
+    CopyDefaultsProc        = P.CopyDefaultsProc.value - 2          # = 24
+    CodeDebugProc           = P.CodeDebugProc.value - 2             # = 25
+    CodeErrHandlingProc     = P.CodeErrHandlingProc.value - 2       # = 26
+
+    # New entries added in LV13 (and one relocated)
+    CopyConvertProcs        = 27
+    InitCodePtrsProc        = 28  # was at 17 before
+    nRunProcs               = 29
+    RunProc                 = 30
+
+    # Generate RunProc2 through RunProc15 (31 through 44)
+    for _i in range(2, 16):
+        locals()[f"RunProc{_i}"] = 29 + _i
+
+    del P
 
 
 class CodeArch(ENUM_TAGS):

--- a/pylabview/LVcode.py
+++ b/pylabview/LVcode.py
@@ -218,9 +218,9 @@ class VICodePtrs_LV13(ENUM_TAGS):
 
 
 class CodeArch(ENUM_TAGS):
-    i386_pc_win32		= 'i386' # Windows 32-bit; used for Windows 3.x with Watcom Win386 extender, then reused for later 32-bit Windowses
+    i386_pc_win32		= 'i386'  # Windows 32-bit; used for Windows 3.x with Watcom Win386 extender, then reused for later 32-bit Windowses  # noqa: E501
     x86_64_pc_win32		= 'wx64'
-    i386_pc_unix		= 'ux86' # Linux, previously was also used for Solaris
+    i386_pc_unix		= 'ux86'  # Linux, previously was also used for Solaris
     x86_64_pc_linux_gnu	= 'ux64'
     i386_apple_darwin	= 'm386'
     x86_64_apple_darwin	= 'mx64'
@@ -243,7 +243,7 @@ def mangleDataName(eName, eKind):
     Uses name mangling from MsVS. Not that I like it, it's just the most
     popular ATM - disassembler will read them.
     """
-    eArr = "PA" if  eKind.endswith("[]") else ""
+    eArr = "PA" if eKind.endswith("[]") else ""
     if eKind.startswith("i8"):
         fullName = "?{}@@3{}CA".format(eName, eArr)
     elif eKind.startswith("i16"):
@@ -264,89 +264,82 @@ def mangleDataName(eName, eKind):
         fullName = "{}".format(eName)
     return fullName
 
+
 def symbolStartFromLowCase(iName):
     oName = iName[0].lower()
-    for i in range(1,len(iName)-1):
+    for i in range(1, len(iName)-1):
         if not (iName[i].isupper() and iName[i+1].isupper()):
             break
         oName += iName[i].lower()
     oName += iName[i:]
     return oName
 
+
 def getVICodeProcName(viCodeItem):
     if not isinstance(viCodeItem, ENUM_TAGS):
         return "Unkn{:02d}Proc".format(int(viCodeItem))
     iName = viCodeItem.name
-    if viCodeItem in (VICodePtrs_LV5.ResetProc,\
-      VICodePtrs_LV6.ResetProc,VICodePtrs_LV7.ResetProc,\
-      VICodePtrs_LV8.ResetProc,VICodePtrs_LV12.ResetProc,\
-      VICodePtrs_LV13.ResetProc,):
+    if viCodeItem in (VICodePtrs_LV5.ResetProc, VICodePtrs_LV6.ResetProc,
+                      VICodePtrs_LV7.ResetProc, VICodePtrs_LV8.ResetProc,
+                      VICodePtrs_LV12.ResetProc, VICodePtrs_LV13.ResetProc,):
         fullName = str(len(iName)+1)+"_"+iName
         fullName = "__ZL"+fullName+"P8DSHeaderP8QElement"
-    elif viCodeItem in (VICodePtrs_LV5.InitProc,\
-      VICodePtrs_LV6.InitProc,VICodePtrs_LV7.InitProc,\
-      VICodePtrs_LV8.InitProc,VICodePtrs_LV12.InitProc,\
-      VICodePtrs_LV13.InitProc,):
+    elif viCodeItem in (VICodePtrs_LV5.InitProc, VICodePtrs_LV6.InitProc,
+                        VICodePtrs_LV7.InitProc, VICodePtrs_LV8.InitProc,
+                        VICodePtrs_LV12.InitProc, VICodePtrs_LV13.InitProc,):
         fullName = str(len(iName)+1)+"_"+iName
         fullName = "__ZL"+fullName+"P8DSHeader"
-    elif viCodeItem in (VICodePtrs_LV5.ErrorStopProc,\
-      VICodePtrs_LV6.ErrorStopProc,VICodePtrs_LV7.ErrorStopProc,\
-      VICodePtrs_LV8.ErrorStopProc,VICodePtrs_LV12.ErrorStopProc,\
-      VICodePtrs_LV13.ErrorStopProc,):
+    elif viCodeItem in (VICodePtrs_LV5.ErrorStopProc, VICodePtrs_LV6.ErrorStopProc,
+                        VICodePtrs_LV7.ErrorStopProc, VICodePtrs_LV8.ErrorStopProc,
+                        VICodePtrs_LV12.ErrorStopProc, VICodePtrs_LV13.ErrorStopProc,):
         fullName = str(len(iName)+1)+"_"+iName
         fullName = "__ZL"+fullName+"P8DSHeaderllP17VirtualInstrument"
-    elif viCodeItem in (VICodePtrs_LV5.DCOCopyToOpProc,\
-      VICodePtrs_LV6.DCOCopyToOpProc,VICodePtrs_LV7.DCOCopyToOpProc,\
-      VICodePtrs_LV8.DCOCopyToOpProc,VICodePtrs_LV12.DCOCopyToOpProc,\
-      VICodePtrs_LV13.DCOCopyToOpProc,):
+    elif viCodeItem in (VICodePtrs_LV5.DCOCopyToOpProc, VICodePtrs_LV6.DCOCopyToOpProc,
+                        VICodePtrs_LV7.DCOCopyToOpProc, VICodePtrs_LV8.DCOCopyToOpProc,
+                        VICodePtrs_LV12.DCOCopyToOpProc, VICodePtrs_LV13.DCOCopyToOpProc,):
         fullName = str(len(iName)+1)+"_"+iName
         fullName = "__ZL"+fullName+"P8DSHeaderlPvlb"
-    elif viCodeItem in (VICodePtrs_LV5.DCOCopyFrOpProc,\
-      VICodePtrs_LV6.DCOCopyFrOpProc,VICodePtrs_LV7.DCOCopyFrOpProc,\
-      VICodePtrs_LV8.DCOCopyFrOpProc,VICodePtrs_LV12.DCOCopyFrOpProc,\
-      VICodePtrs_LV13.DCOCopyFrOpProc,):
+    elif viCodeItem in (VICodePtrs_LV5.DCOCopyFrOpProc, VICodePtrs_LV6.DCOCopyFrOpProc,
+                        VICodePtrs_LV7.DCOCopyFrOpProc, VICodePtrs_LV8.DCOCopyFrOpProc,
+                        VICodePtrs_LV12.DCOCopyFrOpProc, VICodePtrs_LV13.DCOCopyFrOpProc,):
         fullName = str(len(iName)+1)+"_"+iName
         fullName = "__ZL"+fullName+"P8DSHeaderlll"
-    elif viCodeItem in (VICodePtrs_LV5.InitCodePtrsProc,\
-      VICodePtrs_LV6.InitCodePtrsProc,VICodePtrs_LV7.InitCodePtrsProc,\
-      VICodePtrs_LV8.InitCodePtrsProc,VICodePtrs_LV12.InitCodePtrsProc,\
-      VICodePtrs_LV13.InitCodePtrsProc,):
+    elif viCodeItem in (VICodePtrs_LV5.InitCodePtrsProc, VICodePtrs_LV6.InitCodePtrsProc,
+                        VICodePtrs_LV7.InitCodePtrsProc, VICodePtrs_LV8.InitCodePtrsProc,
+                        VICodePtrs_LV12.InitCodePtrsProc, VICodePtrs_LV13.InitCodePtrsProc,):
         fullName = str(len(iName)+1)+"_"+iName
         fullName = "_Z"+fullName+"PP13VICodePtrsRec"
-    elif viCodeItem in (\
-      VICodePtrs_LV6.RunProc,VICodePtrs_LV7.RunProc,\
-      VICodePtrs_LV8.RunProc,VICodePtrs_LV12.RunCodeProc,\
-      VICodePtrs_LV13.RunProc,VICodePtrs_LV13.RunProc2,
-      VICodePtrs_LV13.RunProc3,VICodePtrs_LV13.RunProc4,
-      VICodePtrs_LV13.RunProc5,VICodePtrs_LV13.RunProc6,
-      VICodePtrs_LV13.RunProc7,VICodePtrs_LV13.RunProc8,
-      VICodePtrs_LV13.RunProc9,VICodePtrs_LV13.RunProc10,
-      VICodePtrs_LV13.RunProc11,VICodePtrs_LV13.RunProc12,
-      VICodePtrs_LV13.RunProc13,VICodePtrs_LV13.RunProc14,
-      VICodePtrs_LV13.RunProc15,):
+    elif viCodeItem in (
+      VICodePtrs_LV6.RunProc, VICodePtrs_LV7.RunProc, VICodePtrs_LV8.RunProc, VICodePtrs_LV12.RunCodeProc,
+      VICodePtrs_LV13.RunProc, VICodePtrs_LV13.RunProc2, VICodePtrs_LV13.RunProc3, VICodePtrs_LV13.RunProc4,
+      VICodePtrs_LV13.RunProc5, VICodePtrs_LV13.RunProc6, VICodePtrs_LV13.RunProc7, VICodePtrs_LV13.RunProc8,
+      VICodePtrs_LV13.RunProc9, VICodePtrs_LV13.RunProc10, VICodePtrs_LV13.RunProc11, VICodePtrs_LV13.RunProc12,
+      VICodePtrs_LV13.RunProc13, VICodePtrs_LV13.RunProc14, VICodePtrs_LV13.RunProc15,):
         fullName = str(len(iName)+1)+"_"+iName
         fullName = "_ZL"+fullName+"P8DSHeaderP8QElementl"
     else:
         fullName = "_"+iName
     return fullName
 
+
 def getVICodePtrs(ver):
     from pylabview.LVmisc import isGreaterOrEqVersion
-    if isGreaterOrEqVersion(ver, 13,0,0,0):
+    if isGreaterOrEqVersion(ver, 13,0,0,0):  # noqa: E231
         return VICodePtrs_LV13
-    elif isGreaterOrEqVersion(ver, 12,0,0,0):
+    elif isGreaterOrEqVersion(ver, 12,0,0,0):  # noqa: E231
         return VICodePtrs_LV12
-    elif isGreaterOrEqVersion(ver, 8,0,0,0):
+    elif isGreaterOrEqVersion(ver, 8,0,0,0):  # noqa: E231
         return VICodePtrs_LV8
-    elif isGreaterOrEqVersion(ver, 6,1,0,0):
+    elif isGreaterOrEqVersion(ver, 6,1,0,0):  # noqa: E231
         return VICodePtrs_LV7
-    elif isGreaterOrEqVersion(ver, 6,0,0,0):
+    elif isGreaterOrEqVersion(ver, 6,0,0,0):  # noqa: E231
         return VICodePtrs_LV6
-    elif isGreaterOrEqVersion(ver, 5,0,0,0):
+    elif isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231
         return VICodePtrs_LV5
     return None
 
-def getProcPtrShiftVICode(procPtrShift,addrLen,ver):
+
+def getProcPtrShiftVICode(procPtrShift, addrLen, ver):
     procPos = procPtrShift // addrLen
     VICodePtrs = getVICodePtrs(ver)
     if VICodePtrs is None:

--- a/pylabview/LVheap.py
+++ b/pylabview/LVheap.py
@@ -54,6 +54,44 @@ class ENUM_TAGS(enum.Enum):
     def has_name(cls, name):
         return name in cls.__members__
 
+class Extend_ENUM_TAGS_Meta(type):
+    """ Metaclass to extend or modify an ENUM_TAGS class, as a substitute for inheritance
+    (which does not work for an immutable enum.Enum). It creates a new ENUM_TAGS subclass instead.
+
+    _EXTENDS_ = <parent ENUM_TAGS class>
+    [_DROP_ = <list of members to drop>]
+    """
+    def __new__(mcs, name, bases, classdict):
+        if "_EXTENDS_" not in classdict:
+            raise KeyError(f"Class '{name}' must define the '_EXTENDS_' configuration attribute.")
+        base_class = classdict["_EXTENDS_"]
+        if not isinstance(base_class, type) or not issubclass(base_class, ENUM_TAGS):
+            raise TypeError(f"Invalid configuration in class '{name}': _EXTENDS_ base class must be a subclass of ENUM_TAGS")
+
+        merged_members = {member.name: member.value for member in base_class}
+
+        dropped_names = {item.name for item in classdict.get("_DROP_", []) if isinstance(item, enum.Enum)}
+
+        for key, value in classdict.items():
+            if key.startswith("_") or callable(value):
+                continue
+
+            if isinstance(value, enum.Enum):
+                merged_members[key] = value.value  # Existing key
+            else:
+                merged_members[key] = value  # Newly added key
+
+        for target in dropped_names:
+            if target not in merged_members:
+                raise ValueError(f"Class '{name}': _DROP_ target '{target}' does not exist in {base_class.__name__}!")
+            merged_members.pop(target)
+
+        new_enum = ENUM_TAGS(name, merged_members)
+
+        if "__doc__" in classdict:
+            new_enum.__doc__ = classdict["__doc__"]
+
+        return new_enum
 
 class SL_SYSTEM_TAGS(ENUM_TAGS):
     SL__object = -3

--- a/pylabview/LVmisc.py
+++ b/pylabview/LVmisc.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# flake8: noqa: E302
 
 """ LabView RSRC file format support.
 
@@ -118,6 +117,7 @@ def get_labview_color_palette_256():
 
     cmap = [(0xF1, 0xF1, 0xF1)] + cube_colors[1:-1] + linear_colors + [(0, 0, 0)]
     return [int.from_bytes(rgb, 'big') for rgb in cmap]
+
 
 LABVIEW_COLOR_PALETTE_256 = get_labview_color_palette_256()
 


### PR DESCRIPTION
- Fix whitespace warnings for `LVcode.py`
- Add `.flake8` file that includes settings for individual files
- Refactor VICodePtrs_VI5,6,7,8,12,13 `ENUM_TAGS` classes, adding only the changes rather than enumerating the entire list over and over again (to see the entire list for a particular class, just `list(LVCodePtrs_VIxx)`)
- Add a metaclass to be able to extend or modify an existing `ENUM_TAGS` class (since inheritance does not work for immutable classes)