### PR TITLE
Refactor VICodePtrs_LVxx classes

### DIFF
--- a/pylabview/LVcode.py
+++ b/pylabview/LVcode.py
@@ -11,7 +11,7 @@
 # For a copy, see <https://opensource.org/licenses/MIT>.
 
 
-from pylabview.LVheap import ENUM_TAGS
+from pylabview.LVheap import ENUM_TAGS, extend_ENUM_TAGS
 
 
 class VICodePtrs_LV5(ENUM_TAGS):
@@ -29,193 +29,124 @@ class VICodePtrs_LV5(ENUM_TAGS):
     SaveProc    = 7
     ErrorStopProc = 8
     ConstantProc = 9
-    RngChkProc  = 10
-    DCODfltProc = 11
+    RngChkProc    = 10
+    DCODfltProc    = 11
     SetAllDfltsProc = 12
-    DCOCopyProc = 13
+    DCOCopyProc	    = 13
     DCOCopyToOpProc = 14
     DCOCopyFrOpProc = 15
-    RunCode     = 16
+    RunCode	        = 16
     InitCodePtrsProc = 17
     PrxyCallerInitCPProc = 18
-    ReInitProc  = 19
-    CRoutine    = 20
+    ReInitProc      = 19
+    CRoutine        = 20
 
 
-class VICodePtrs_LV6(ENUM_TAGS):
+@extend_ENUM_TAGS(VICodePtrs_LV5)
+class VICodePtrs_LV6:
     """ List of VI Code Pointers from LV6 before LV6.1
 
     These callbacks can be set from InitCodePtrsProc within VI compiled code.
     Since LV6.1 this no longer applies as one of the callbacks was renamed.
     """
-    CRoutine        = 0         # was 20 before; 0 used to be GoProc, moved to 19
-    RetryProc       = 1
-    ResumeProc      = 2
-    ResetProc       = 3
-    DisposeProc     = 4
-    InitProc        = 5
-    LoadProc        = 6
-    SaveProc        = 7
-    ErrorStopProc   = 8
-    ConstantProc    = 9
-    RngChkProc      = 10
-    DCODefaultProc  = 11        # was DCODfltProc before
-    SetAllDefaultProc = 12      # was SetAllDfltsProc before
-    DCOCopyProc     = 13
-    DCOCopyToOpProc = 14
-    DCOCopyFrOpProc = 15
-    RunProc         = 16        # was RunCode before
-    InitCodePtrsProc = 17
-    ReInitProc      = 18        # was PrxyCallerInitCPProc before
-    GoProc          = 19        # was 0 before
+    CRoutine            = 0         # was 20 before; 0 used to be GoProc, moved to 19
+    DCODfltProc         = None      # renamed to:
+    DCODefaultProc      = 11
+    SetAllDfltsProc     = None      # renamed to:
+    SetAllDefaultProc   = 12
+    RunCode             = None      # renamed to:
+    RunProc             = 16
+    PrxyCallerInitCPProc = None     # was 18 before, became:
+    ReInitProc          = 18        # was 19 before
+    GoProc              = 19        # was 0 before
 
 
-class VICodePtrs_LV7(ENUM_TAGS):
+@extend_ENUM_TAGS(VICodePtrs_LV6)
+class VICodePtrs_LV7:
     """ List of VI Code Pointers from LV6.1-LV7
 
     These callbacks can be set from InitCodePtrsProc within VI compiled code.
     """
-    CRoutine        = 0
-    RetryProc       = 1
-    ResumeProc      = 2
-    ResetProc       = 3
-    DisposeProc     = 4
-    InitProc        = 5
-    LoadProc        = 6
-    SaveProc        = 7
-    ErrorStopProc   = 8
-    ConstantProc    = 9
-    RngChkProc      = 10
-    DCODefaultProc  = 11
-    SetAllDefaultProc = 12
-    DCOCopyProc     = 13
-    DCOCopyToOpProc = 14
-    DCOCopyFrOpProc = 15
-    RunProc         = 16
-    InitCodePtrsProc = 17
-    ReserveUnReserveProc = 18   # 18 used to be ReInitProc
-    GoProc          = 19
+    ReInitProc          = None      # was 18 before, became:
+    ReserveUnReserveProc = 18
 
 
-class VICodePtrs_LV8(ENUM_TAGS):
+@extend_ENUM_TAGS(VICodePtrs_LV7)
+class VICodePtrs_LV8:
     """ List of VI Code Pointers from LV8-LV11
 
     These callbacks can be set from InitCodePtrsProc within VI compiled code.
     """
-    CRoutine        = 0
-    RetryProc       = 1
-    ResumeProc      = 2
-    ResetProc       = 3
-    DisposeProc     = 4
-    InitProc        = 5
-    LoadProc        = 6
-    SaveProc        = 7
-    ErrorStopProc   = 8
-    ConstantProc    = 9
-    CompareProc     = 10        # 10 used to be RngChkProc
-    DCODefaultProc  = 11
-    SetAllDefaultProc = 12
-    DCOCopyProc     = 13
-    DCOCopyToOpProc = 14
-    DCOCopyFrOpProc = 15
-    RunProc         = 16        # Calls the method received in parameter
-    InitCodePtrsProc = 17
-    ReserveUnReserveProc = 18
-    GoProc          = 19
-    AcquireDSProc   = 20        # The 4 entries added in LV10
-    ReleaseDSProc   = 21
+    RngChkProc          = None      # was 10 before, became:
+    CompareProc         = 10
+
+    # New entries added in LV10
+    AcquireDSProc       = 20
+    ReleaseDSProc       = 21
     AcquireDSStaticProc = 22
     ReleaseDSStaticProc = 23
 
 
-class VICodePtrs_LV12(ENUM_TAGS):
+@extend_ENUM_TAGS(VICodePtrs_LV8)
+class VICodePtrs_LV12:
     """ List of VI Code Pointers from LV12
 
     These callbacks can be set from InitCodePtrsProc within VI compiled code.
     Pointers are either 32-bit or 64-bit, depending on architecture.
     """
-    CRoutine        = 0
-    RetryProc       = 1
-    ResumeProc      = 2
-    ResetProc       = 3
-    DisposeProc     = 4
-    InitProc        = 5
-    LoadProc        = 6
-    SaveProc        = 7
-    ErrorStopProc   = 8
-    ConstantProc    = 9
-    CompareProc     = 10
-    DCODefaultProc  = 11
-    SetAllDefaultProc = 12
-    DCOCopyProc     = 13
-    DCOCopyToOpProc = 14
-    DCOCopyFrOpProc = 15
-    RunCodeProc     = 16        # was RunProc before (and RunCode earlier on)
-    InitCodePtrsProc = 17
-    ReserveUnReserveProc = 18
-    GoProc          = 19
-    DSTMNeededProc  = 20        # 20 used to be AcquireDSProc
-    GetDataSpaceSizeProc = 21   # 21 used to be ReleaseDSProc
-    InflateDataSpaceProc = 22   # 22 used to be AcquireDSStaticProc
-    DeflateDataSpaceProc = 23   # 23 used to be ReleaseDSStaticProc
-    ShrinkDataSpaceProc = 24    # Five more entries added in LV12
-    UnflattenDefaultsProc = 25
-    CopyDefaultsProc = 26
-    CodeDebugProc   = 27
-    CodeErrHandlingProc = 28
+    RunProc                 = None  # renamed to:
+    RunCodeProc             = 16
+
+    # Entries removed
+    AcquireDSProc           = None  # was 20
+    ReleaseDSProc           = None  # was 21
+    AcquireDSStaticProc     = None  # was 22
+    ReleaseDSStaticProc     = None  # was 23
+
+    # New entries added in LV12
+    DSTMNeededProc          = 20
+    GetDataSpaceSizeProc    = 21
+    InflateDataSpaceProc    = 22
+    DeflateDataSpaceProc    = 23
+    ShrinkDataSpaceProc     = 24
+    UnflattenDefaultsProc   = 25
+    CopyDefaultsProc        = 26
+    CodeDebugProc           = 27
+    CodeErrHandlingProc     = 28
 
 
-class VICodePtrs_LV13(ENUM_TAGS):
+@extend_ENUM_TAGS(VICodePtrs_LV12)
+class VICodePtrs_LV13:
     """ List of VI Code Pointers from LV13-LV20
 
     These callbacks can be set from InitCodePtrsProc within VI compiled code.
     Pointers are either 32-bit or 64-bit, depending on architecture.
     """
-    CRoutine        = 0
-    RetryProc       = 1
-    ResumeProc      = 2
-    ResetProc       = 3
-    DisposeProc     = 4
-    InitProc        = 5
-    LoadProc        = 6
-    SaveProc        = 7
-    ErrorStopProc   = 8
-    ConstantProc    = 9
-    CompareProc     = 10
-    DCODefaultProc  = 11
-    SetAllDefaultProc = 12
-    DCOCopyProc     = 13
-    DCOCopyToOpProc = 14
-    DCOCopyFrOpProc = 15
-    ReserveUnReserveProc = 16   # was at 18; 16 used to be RunCodeProc
-    GoProc          = 17        # was at 19; 17 used to be InitCodePtrsProc, moved to 28
-    DSTMNeeded      = 18        # was at 20; this and the next 8 entries changed by -2
-    GetDataSpaceSizeProc = 19
-    InflateDataSpaceProc = 20
-    DeflateDataSpaceProc = 21
-    ShrinkDataSpaceProc = 22
-    UnflattenDefaultsProc = 23
-    CopyDefaultsProc = 24
-    CodeDebugProc   = 25
-    CodeErrHandlingProc = 26
-    CopyConvertProcs = 27       # added in LV13
-    InitCodePtrsProc = 28       # was at 17 before
-    nRunProcs       = 29        # added in LV13
-    RunProc         = 30        # RunProc and RunProc2..15 are new in LV13
-    RunProc2        = 31
-    RunProc3        = 32
-    RunProc4        = 33
-    RunProc5        = 34
-    RunProc6        = 35
-    RunProc7        = 36
-    RunProc8        = 37
-    RunProc9        = 38
-    RunProc10       = 39
-    RunProc11       = 40
-    RunProc12       = 41
-    RunProc13       = 42
-    RunProc14       = 43
-    RunProc15       = 44
+    RunCodeProc             = None  # was 16 before
+
+    # LV12 entries 18 to 28 shift down 2 positions (become 16 to 26)
+    ReserveUnReserveProc    = 16
+    GoProc                  = 17    # used to be InitCodePtrsProc, moved to 28
+    DSTMNeededProc          = None  # renamed to:
+    DSTMNeeded              = 18
+    GetDataSpaceSizeProc    = 19
+    InflateDataSpaceProc    = 20
+    DeflateDataSpaceProc    = 21
+    ShrinkDataSpaceProc     = 22
+    UnflattenDefaultsProc   = 23
+    CopyDefaultsProc        = 24
+    CodeDebugProc           = 25
+    CodeErrHandlingProc     = 26
+
+    # New entries added in LV13 (and one relocated)
+    CopyConvertProcs        = 27
+    InitCodePtrsProc        = 28    # was at 17 before
+    nRunProcs               = 29
+    RunProc                 = 30
+
+    # Generate RunProc2 through RunProc15 (31 through 44)
+    for _i in range(2, 16):
+        locals()[f"RunProc{_i}"] = 31 + (_i - 2)
 
 
 class CodeArch(ENUM_TAGS):

--- a/pylabview/LVheap.py
+++ b/pylabview/LVheap.py
@@ -55,6 +55,46 @@ class ENUM_TAGS(enum.Enum):
         return name in cls.__members__
 
 
+def extend_ENUM_TAGS(parent_enum):
+    """Decorator to merge an existing ENUM_TAGS's members into a new ENUM_TAGS subclass."""
+    if not issubclass(parent_enum, ENUM_TAGS):
+        raise TypeError(f"Invalid parent class '{parent_enum.__name__}': must be a subclass of ENUM_TAGS")
+
+    def decorator(cls_def):
+        # Obtain name/value pairs from the parent
+        merged_members = {m.name: m.value for m in parent_enum}
+
+        # Add the new names/values from the definition class (cls_def)
+        for key, value in cls_def.__dict__.items():
+            if key.startswith("_") or callable(value):
+                continue
+            if value is None:
+                if key not in merged_members:
+                    raise KeyError(f"Key '{cls_def.__name__}.{key}' does not exist in parent '{parent_enum.__name__}'")
+                merged_members.pop(key)
+            else:
+                merged_members[key] = value
+
+        # Ensure that member values are unique
+        if len(merged_members.values()) != len(set(merged_members.values())):
+            raise ValueError(f"Duplicate enum integer values detected in '{cls_def.__name__}'")
+        
+        # Sort members
+        def sort_by_value(item): _key, value = item; return value
+        merged_members = dict(sorted(merged_members.items(), key=sort_by_value))
+            
+        # Dynamically construct a new ENUM_TAGS class
+        new_enum = ENUM_TAGS(cls_def.__name__, merged_members)
+
+        # Copy the docstring
+        if cls_def.__doc__:
+            new_enum.__doc__ = cls_def.__doc__
+
+        return new_enum
+    
+    return decorator
+
+
 class SL_SYSTEM_TAGS(ENUM_TAGS):
     SL__object = -3
     SL__array = -4


### PR DESCRIPTION
Proposed changes:
- LVcode.py: Refactor VICodePtrs_VI5,6,7,8,12,13 `ENUM_TAGS` classes, adding only the changes rather than repeating the entire list of tags each time (DRY: Don't Repeat Yourself, rather than WET: We Enjoy Typing)
- LVheap.py: Add a decorator `extend_ENUM_TAGS' to be able to modify and extend an existing `ENUM_TAGS` class

This is an attempt at an improvement of an earlier PR #28, which proposed a metaclass to be able to extend an ENUM_TAGS class (since inheritance does not work for immutable classes).  The current PR proposes using a decorator instead, hence 
- no metaclass is needed; a decorator is simpler; and it avoids the complication of makeshift `_EXTEND_` and `_DROP_`;
- tags slated for removal are clearly marked simply by setting `<tag> = None`.

Moreover, the decorator
- ensures that tag values are unique
- keeps the keys sorted, convenient when you want to see the entire list for a particular LV version: just `list(VICodePtrs_LVxx)`


The decorator comes at a price of 23 'standard lines of code' (sloc); however, 6 of these are for providing sensible error messages for extra checks, sorting _etc_. In fact only 12 sloc are needed for a functional decorator. In return, it saves  
LV6: 20 -> 10 sloc
LV7: 20 -> 2
LV8: 24 -> 6
LV12: 29 -> 15
LV13: 30 -> 16 
for a total savings of 10+18+18+14+14 = 74 sloc 
(Moreover, 15 `RunProcN` entries in LV13 can be generated with 2 sloc.)
In the balance, it would seem this comes out as a net positive.

The [Rule of three](https://en.wikipedia.org/wiki/Rule_of_three_(computer_programming)) also seems to suggest that the refactoring is worthwhile.
