### PR TITLE
LVblock imports

### DIFF
--- a/pylabview/LVblock.py
+++ b/pylabview/LVblock.py
@@ -3022,8 +3022,6 @@ class FTAB(CompleteBlock):
         return data_buf
 
     def initWithXMLSectionFont(self, section, font_elem):
-        section_num = section.start.section_idx
-
         fnEntry = self.newFontEntry()
         tmp = font_elem.get("Prop2")
         if tmp is not None:
@@ -3669,7 +3667,6 @@ class LVSR(CompleteBlock):
 
     def expectedRSRCSize(self, section_num):
         section = self.sections[section_num]
-        ver = self.vi.getFileVersion()
         exp_whole_len = 68
 
         if LV.isGreaterOrEqVersion(section.version, 7,0):  # noqa: E231

--- a/pylabview/LVblock.py
+++ b/pylabview/LVblock.py
@@ -24,6 +24,8 @@ from types import SimpleNamespace
 from ctypes import c_ubyte, c_uint32, c_int32, sizeof
 
 import pylabview.LVmisc as LV
+from pylabview.LVmisc import eprint, isSmallerVersion, isGreaterOrEqVersion, RSRCStructure, \
+    getPrettyStrFromRsrcType, getRsrcTypeFromPrettyStr, importXMLBitfields, exportXMLBitfields
 import pylabview.LVxml as ET
 import pylabview.LVdatatype as LVdatatype
 import pylabview.LVinstrument as LVinstrument
@@ -41,7 +43,7 @@ class BLOCK_CODING(enum.Enum):
     XOR = 3
 
 
-class BlockHeader(LV.RSRCStructure):
+class BlockHeader(RSRCStructure):
     _fields_ = [('ident', c_ubyte * 4),	 # 0 4-byte block identifier
                 ('count', c_uint32),	 # 4 Amount of sections for that block
                 ('offset', c_uint32),	 # 8 Offset to the array of BlockSectionStart structs
@@ -56,7 +58,7 @@ class BlockHeader(LV.RSRCStructure):
         return ret
 
 
-class BlockSectionStart(LV.RSRCStructure):
+class BlockSectionStart(RSRCStructure):
     """ Info Header of a section
 
         Stores location of its data, but also name offset and index
@@ -78,7 +80,7 @@ class BlockSectionStart(LV.RSRCStructure):
         return ret
 
 
-class BlockSectionData(LV.RSRCStructure):
+class BlockSectionData(RSRCStructure):
     """ Header for raw data of a section within a block
 
         Stores only size of the raw data which follows.
@@ -162,7 +164,7 @@ class Block(object):
         section_num = section.start.section_idx
         if self.po.print_map == "RSRC" and section.block_coding == BLOCK_CODING.NONE \
            or self.po.print_map == type(self).__name__:
-            pretty_ident = LV.getPrettyStrFromRsrcType(self.ident)
+            pretty_ident = getPrettyStrFromRsrcType(self.ident)
             if self.po.print_map == "RSRC":
                 print_map_base = self.getDataPosInContainer(section_num=section_num)
             else:
@@ -194,7 +196,7 @@ class Block(object):
             self.vi.binflsthead.blockinfo_offset + \
             self.header.offset
         if self.po.print_map == "RSRC":
-            pretty_ident = LV.getPrettyStrFromRsrcType(self.ident)
+            pretty_ident = getPrettyStrFromRsrcType(self.ident)
 
         fh = self.vi.rsrc_fh
         fh.seek(start_pos)
@@ -232,7 +234,7 @@ class Block(object):
         """
         fh = self.vi.rsrc_fh
         if self.po.print_map == "RSRC":
-            pretty_ident = LV.getPrettyStrFromRsrcType(self.ident)
+            pretty_ident = getPrettyStrFromRsrcType(self.ident)
         # After BlockSectionStart list, there is Block Section Names list; only some sections have a name
         names_start = self.vi.getPositionOfBlockSectionNames()
         names_end = self.vi.getPositionOfBlockInfoEnd()
@@ -291,7 +293,7 @@ class Block(object):
 
         At the point it is executed, other blocks and sections are inaccessible.
         """
-        self.ident = LV.getRsrcTypeFromPrettyStr(block_elem.tag)
+        self.ident = getRsrcTypeFromPrettyStr(block_elem.tag)
         self.header = BlockHeader(self.po)
         self.header.ident = (c_ubyte * 4).from_buffer_copy(self.ident)
         self.active_section_num = None
@@ -321,8 +323,8 @@ class Block(object):
                     section.name_obj = LVclasses.LVPath0(self.vi, blockref, self.po)
                     section.name_obj.initWithXML(subelem)
                     if section.name_text is not None:
-                        LV.eprint("{:s}: Warning: Block {} section {} has both 'Name' attrib and 'NameObject' tag."
-                                  .format(self.vi.src_fname, self.ident, i))
+                        eprint("{:s}: Warning: Block {} section {} has both 'Name' attrib and 'NameObject' tag."
+                               .format(self.vi.src_fname, self.ident, i))
                     section.name_text = section.name_obj.prepareRSRCData()
                     break
 
@@ -409,7 +411,7 @@ class Block(object):
 
         fh = self.vi.rsrc_fh
         if self.po.print_map == "RSRC":
-            pretty_ident = LV.getPrettyStrFromRsrcType(self.ident)
+            pretty_ident = getPrettyStrFromRsrcType(self.ident)
         for snum, section in sorted(self.sections.items()):
             if snum >= section_count:
                 break
@@ -792,7 +794,7 @@ class Block(object):
     def exportFilesBase(self, snum, section):
         """ Prepare a base for file names of any files created by data export
         """
-        pretty_ident = LV.getPrettyStrFromRsrcType(self.ident)
+        pretty_ident = getPrettyStrFromRsrcType(self.ident)
         block_fpath = os.path.dirname(self.po.xml)
 
         fname_base = self.po.filebase
@@ -830,7 +832,7 @@ class Block(object):
         """
         from pylabview.LVrsrcontainer import FILE_FMT_TYPE
         ver = self.vi.getFileVersion()
-        pretty_ident = LV.getPrettyStrFromRsrcType(self.ident)
+        pretty_ident = getPrettyStrFromRsrcType(self.ident)
 
         elem = ET.Element(pretty_ident)
         if len(self.full_name) > 0:
@@ -840,7 +842,7 @@ class Block(object):
             section_elem = ET.SubElement(elem, "Section")
             section_elem.set("Index", str(snum))
 
-            if self.vi.ftype == FILE_FMT_TYPE.LLB or LV.isSmallerVersion(ver, 8,0,0):  # noqa: E231
+            if self.vi.ftype == FILE_FMT_TYPE.LLB or isSmallerVersion(ver, 8,0,0):  # noqa: E231
                 # Vefied to be non-zero in LV7.1 files, is zero in LV8.6 files
                 block_int5 = section.start.int5
             else:
@@ -973,12 +975,12 @@ class CompleteBlock(Block):
                 import sys
                 import traceback
                 traceback.print_exc(file=sys.stdout)
-            LV.eprint("{:s}: Warning: Block {} section {} parse exception: {}."
-                      .format(self.vi.src_fname, self.ident, section_num, str(e)))
+            eprint("{:s}: Warning: Block {} section {} parse exception: {}."
+                   .format(self.vi.src_fname, self.ident, section_num, str(e)))
         if bldata.tell() < totlen:
             section.parse_failed = True
-            LV.eprint("{:s}: Warning: Block {} section {} size is {} and does not match parsed size {}"
-                      .format(self.vi.src_fname, self.ident, section_num, totlen, bldata.tell()))
+            eprint("{:s}: Warning: Block {} section {} size is {} and does not match parsed size {}"
+                   .format(self.vi.src_fname, self.ident, section_num, totlen, bldata.tell()))
         if section.parse_failed:
             bldata.seek(startpos)
             Block.parseRSRCData(self, section_num, bldata)
@@ -999,8 +1001,8 @@ class CompleteBlock(Block):
 
         # Do not re-create raw data if parsing failed and we still have the original
         if (section.parse_failed and self.hasRawData(section_num)):
-            LV.eprint("{:s}: Warning: Block {} section {} left in original raw form, without re-building"
-                      .format(self.vi.src_fname, self.ident, section_num))
+            eprint("{:s}: Warning: Block {} section {} left in original raw form, without re-building"
+                   .format(self.vi.src_fname, self.ident, section_num))
             return
 
         data_buf = b''
@@ -1012,8 +1014,8 @@ class CompleteBlock(Block):
                 import sys
                 import traceback
                 traceback.print_exc(file=sys.stdout)
-            LV.eprint("{:s}: Warning: Block {} section {} binary prepare exception: {}."
-                      .format(self.vi.src_fname, self.ident, section_num, str(e)))
+            eprint("{:s}: Warning: Block {} section {} binary prepare exception: {}."
+                   .format(self.vi.src_fname, self.ident, section_num, str(e)))
 
         # Do not re-create raw data if parsing failed and we still have the original
         if section.parse_failed:
@@ -1021,8 +1023,8 @@ class CompleteBlock(Block):
                 raise RuntimeError("Block {} section {} could not prepare binary data"
                                    .format(self.ident, section_num))
             else:
-                LV.eprint("{:s}: Warning: Block {} section {} left in original raw form, without re-building"
-                          .format(self.vi.src_fname, self.ident, section_num))
+                eprint("{:s}: Warning: Block {} section {} left in original raw form, without re-building"
+                       .format(self.vi.src_fname, self.ident, section_num))
             return
 
         exp_whole_len = self.expectedRSRCSize(section_num)
@@ -1165,8 +1167,8 @@ class CompleteBlock(Block):
                 import sys
                 import traceback
                 traceback.print_exc(file=sys.stdout)
-            LV.eprint("{:s}: Warning: Block {} section {} XML export exception: {}."
-                      .format(self.vi.src_fname, self.ident, section_num, str(e)))
+            eprint("{:s}: Warning: Block {} section {} XML export exception: {}."
+                   .format(self.vi.src_fname, self.ident, section_num, str(e)))
             Block.exportXMLSection(self, section_elem, section_num, section, fname_base)
             return
 
@@ -1199,7 +1201,7 @@ class VarCodingBlock(Block):
     def setDefaultEncoding(self, section_num):
         section = self.sections[section_num]
         ver = self.vi.getFileVersion()
-        if LV.isGreaterOrEqVersion(ver, 6,0,0):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 6,0,0):  # noqa: E231
             section.block_coding = BLOCK_CODING.ZLIB
         else:
             section.block_coding = BLOCK_CODING.NONE
@@ -1336,7 +1338,7 @@ class FPTD(CompleteBlock):
         The block contains single TD index for LV 8.6.0, it does not for LV6.0.1
         """
         ver = self.vi.getFileVersion()
-        return LV.isGreaterOrEqVersion(ver, 7,0,0)  # noqa: E231
+        return isGreaterOrEqVersion(ver, 7,0,0)  # noqa: E231
 
     def parseRSRCSectionData(self, section_num, bldata):
         section = self.sections[section_num]
@@ -1913,12 +1915,12 @@ class STR(SingleStringBlock):
     def isSingleShortString(self):
         from pylabview.LVrsrcontainer import FILE_FMT_TYPE
         ver = self.vi.getFileVersion()
-        return (self.vi.ftype == FILE_FMT_TYPE.LLB) or LV.isSmallerVersion(ver, 8,0,0)  # noqa: E231
+        return (self.vi.ftype == FILE_FMT_TYPE.LLB) or isSmallerVersion(ver, 8,0,0)  # noqa: E231
 
     def isSingleLVVariant(self):
         from pylabview.LVrsrcontainer import FILE_FMT_TYPE
         ver = self.vi.getFileVersion()
-        return (self.vi.ftype == FILE_FMT_TYPE.VI) and LV.isGreaterOrEqVersion(ver, 8,0,0)  # noqa: E231
+        return (self.vi.ftype == FILE_FMT_TYPE.VI) and isGreaterOrEqVersion(ver, 8,0,0)  # noqa: E231
 
     def parseRSRCSectionData(self, section_num, bldata):
         section = self.sections[section_num]
@@ -2163,7 +2165,7 @@ class STRG(StringListBlock):
         """ Properly sets storage mode based on LV version
         """
         ver = self.vi.getFileVersion()
-        if LV.isGreaterOrEqVersion(ver, 4,0,0):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 4,0,0):  # noqa: E231
             section.count_len = 0
             section.size_len = 4
         else:  # Tested on LV2.5
@@ -2206,7 +2208,7 @@ class LSTsh(StringListBlock):
         if vers is None:
             return 1
         ver = self.vi.getFileVersion()
-        if LV.isSmallerVersion(ver, 11,0,0,0):  # noqa: E231
+        if isSmallerVersion(ver, 11,0,0,0):  # noqa: E231
             return 4
         return 1
 
@@ -2285,7 +2287,7 @@ class LinkObjRefs(CompleteBlock):
             raise AttributeError("List of LinkObjects incorrectly started with {}".format(nextLinkInfo))
         section.ident = bldata.read(4)
         self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "LinkObject[{}].Ident".format(0))
-        if LV.isSmallerVersion(ver, 14,0,0,3):  # noqa: E231
+        if isSmallerVersion(ver, 14,0,0,3):  # noqa: E231
             section.unk1 = LV.readPStr(bldata, 2, self.po)
             self.appendPrintMapEntry(section, bldata.tell(), 1+len(section.unk1), 2, "LinkObject[{}].Unk1".format(0))
             wordlen = int.from_bytes(bldata.read(2), byteorder='big', signed=False)
@@ -2329,7 +2331,7 @@ class LinkObjRefs(CompleteBlock):
         data_buf = b''
         data_buf += int(1).to_bytes(2, byteorder='big', signed=False)  # nextLinkInfo
         data_buf += section.ident
-        if LV.isSmallerVersion(ver, 14,0,0,3):  # noqa: E231
+        if isSmallerVersion(ver, 14,0,0,3):  # noqa: E231
             data_buf += LV.preparePStr(section.unk1, 2, self.po)
             data_buf += int(len(section.unk2)/2).to_bytes(2, byteorder='big', signed=False)
             data_buf += section.unk2
@@ -2345,7 +2347,7 @@ class LinkObjRefs(CompleteBlock):
         ver = self.vi.getFileVersion()
         exp_whole_len = 0
         exp_whole_len += 2 + 4
-        if LV.isSmallerVersion(ver, 14,0,0,3):  # noqa: E231
+        if isSmallerVersion(ver, 14,0,0,3):  # noqa: E231
             str_len = 1 + len(section.unk1)
             uneven_len = str_len % 2
             if uneven_len > 0:
@@ -2363,7 +2365,7 @@ class LinkObjRefs(CompleteBlock):
         return exp_whole_len
 
     def initWithXMLList(self, section, list_elem):
-        section.ident = LV.getRsrcTypeFromPrettyStr(list_elem.tag)
+        section.ident = getRsrcTypeFromPrettyStr(list_elem.tag)
         unk1 = list_elem.get("Unk1")
         if unk1 is not None:
             section.unk1 = unk1.encode(self.vi.textEncoding)
@@ -2372,7 +2374,7 @@ class LinkObjRefs(CompleteBlock):
             section.unk2 = bytes.fromhex(unk2)
         blockref = (self.ident, section.start.section_idx,)
         for subelem in list_elem:
-            lnkobj_ident = LV.getRsrcTypeFromPrettyStr(subelem.tag)
+            lnkobj_ident = getRsrcTypeFromPrettyStr(subelem.tag)
             client = LVlinkinfo.newLinkObject(self.vi, blockref, section.ident, lnkobj_ident, self.po)
             section.content.append(client)
             client.initWithXML(subelem)
@@ -2404,7 +2406,7 @@ class LinkObjRefs(CompleteBlock):
         pass
 
     def exportXMLSectionData(self, section_elem, section_num, section, fname_base):
-        pretty_ident = LV.getPrettyStrFromRsrcType(section.ident)
+        pretty_ident = getPrettyStrFromRsrcType(section.ident)
         list_elem = ET.SubElement(section_elem, pretty_ident)
         if len(section.unk1) > 0 or len(section.unk2) > 0:
             list_elem.set("Unk1", section.unk1.decode(self.vi.textEncoding))
@@ -2491,7 +2493,7 @@ class DFDS(CompleteBlock):
         section = self.sections[section_num]
         ver = self.vi.getFileVersion()
         # Verified uncompressed in LV7.1.0, ZLIB compressed in LV8.6
-        if LV.isGreaterOrEqVersion(ver, 8,0,0):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 8,0,0):  # noqa: E231
             section.block_coding = BLOCK_CODING.ZLIB
         else:
             section.block_coding = BLOCK_CODING.NONE
@@ -2509,7 +2511,7 @@ class DFDS(CompleteBlock):
 
         if TM is None:
             raise RuntimeError("No type map block to put default data into types")
-        elif LV.isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
+        elif isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
             TypeMap = TM.getTypeMap()
             for tmEntry in TypeMap:
                 if (tmEntry.flags & LVdatatype.TM_FLAGS.TMFBit3) != 0 or \
@@ -2532,7 +2534,7 @@ class DFDS(CompleteBlock):
         ver = self.vi.getFileVersion()
 
         section.content = []
-        if LV.isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
             blockref = (self.ident, section.start.section_idx,)
             for tmEntry, defDataType in self.getTypeMapWithDefltData():
                 df = None
@@ -3220,7 +3222,7 @@ class DTHP(CompleteBlock):
         section.tdCount = 0
         section.content = []
 
-        if LV.isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
             section.tdCount = LV.readVariableSizeFieldU2p2(bldata)
             # If there is no count provided, then there is no shift
             # LV14 writes it like this; though it doesn't support this while reading
@@ -3237,7 +3239,7 @@ class DTHP(CompleteBlock):
         ver = self.vi.getFileVersion()
 
         data_buf = b''
-        if LV.isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
             data_buf += LV.prepareVariableSizeFieldU2p2(section.tdCount)
             if section.tdCount > 0:
                 data_buf += LV.prepareVariableSizeFieldU2p2(section.indexShift)
@@ -3250,7 +3252,7 @@ class DTHP(CompleteBlock):
         section = self.sections[section_num]
         ver = self.vi.getFileVersion()
 
-        if LV.isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
             exp_whole_len = 0
             exp_whole_len += 2
             if section.tdCount > 0:
@@ -3274,7 +3276,7 @@ class DTHP(CompleteBlock):
     def exportXMLSectionData(self, section_elem, section_num, section, fname_base):
         ver = self.vi.getFileVersion()
 
-        if LV.isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
             # This is only for a comment, allowed to return None
             VCTP = self.vi.get('VCTP')
 
@@ -3327,7 +3329,7 @@ class DSTM(CompleteBlock):
         section = self.sections[section_num]
         ver = self.vi.getFileVersion()
         # Verified uncompressed in LV7.1.0, compressed in LV8.6
-        if LV.isGreaterOrEqVersion(ver, 8,0,0):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 8,0,0):  # noqa: E231
             section.block_coding = BLOCK_CODING.ZLIB
         else:
             section.block_coding = BLOCK_CODING.NONE
@@ -3367,7 +3369,7 @@ class TM80(CompleteBlock):
     def setDefaultEncoding(self, section_num):
         section = self.sections[section_num]
         ver = self.vi.getFileVersion()
-        if LV.isGreaterOrEqVersion(ver, 10,0,0):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 10,0,0):  # noqa: E231
             section.block_coding = BLOCK_CODING.ZLIB
         else:
             section.block_coding = BLOCK_CODING.NONE
@@ -3412,7 +3414,7 @@ class TM80(CompleteBlock):
             if (subelem.tag == "NameObject"):
                 pass  # Items parsed somewhere else
             elif (subelem.tag == "Client"):
-                val = LV.importXMLBitfields(LVdatatype.TM_FLAGS, subelem)
+                val = importXMLBitfields(LVdatatype.TM_FLAGS, subelem)
                 section.content.append(val)
             else:
                 raise AttributeError("Section contains unexpected tag")
@@ -3439,7 +3441,7 @@ class TM80(CompleteBlock):
 
             subelem = ET.SubElement(section_elem, "Client")
 
-            LV.exportXMLBitfields(LVdatatype.TM_FLAGS, subelem, val)
+            exportXMLBitfields(LVdatatype.TM_FLAGS, subelem, val)
 
         if len(section.content) == 0:
             comment_elem = ET.Comment("List of types is empty")
@@ -3462,8 +3464,8 @@ class TM80(CompleteBlock):
             tmEntry.flags = val
             tmEntry.td = VCTP.getTopType(tmEntry.index)
             if tmEntry.td is None:
-                LV.eprint("{:s}: Warning: Block {} section {} references VCTP type {}+{} which does not exist."
-                          .format(self.vi.src_fname, self.ident, section_num, section.indexShift, i))
+                eprint("{:s}: Warning: Block {} section {} references VCTP type {}+{} which does not exist."
+                       .format(self.vi.src_fname, self.ident, section_num, section.indexShift, i))
 
         return tmEntry
 
@@ -3502,8 +3504,8 @@ class TM80(CompleteBlock):
             tmEntry.flags = val
             tmEntry.td = VCTP.getTopType(tmEntry.index)
             if tmEntry.td is None:
-                LV.eprint("{:s}: Warning: Block {} section {} references VCTP type {}+{} which does not exist."
-                          .format(self.vi.src_fname, self.ident, section_num, section.indexShift, i))
+                eprint("{:s}: Warning: Block {} section {} references VCTP type {}+{} which does not exist."
+                       .format(self.vi.src_fname, self.ident, section_num, section.indexShift, i))
             else:
                 typeMap.append(tmEntry)
 
@@ -3601,22 +3603,22 @@ class LVSR(CompleteBlock):
         # Additional data, exists only in newer versions
         # sizeof(LVSR) per version: 6.0.1->68 7.1.0->96 8.6b7->120 9.0b25->120 9.0->120 10.0b84->120 10.0->136 11.0.1->136
         # 12.0->136 13.0->136 14.0->137
-        if LV.isGreaterOrEqVersion(section.version, 7,0):  # noqa: E231
+        if isGreaterOrEqVersion(section.version, 7,0):  # noqa: E231
             section.alignGridFP = int(data.alignGridFP)
             section.alignGridBD = int(data.alignGridBD)
             section.field4C = int(data.field4C)
             section.ctrlIndStyle = int(data.ctrlIndStyle)
             section.field50_md5 = bytes(data.field50_md5)
-        if LV.isGreaterOrEqVersion(section.version, 8,0):  # noqa: E231
+        if isGreaterOrEqVersion(section.version, 8,0):  # noqa: E231
             section.libpass_md5 = bytes(data.libpass_md5)
             section.libpass_text = None
             section.field70 = int(data.field70)
             section.field74 = int(data.field74)
-        if LV.isGreaterOrEqVersion(section.version, 10,0, stage='release'):  # noqa: E231
+        if isGreaterOrEqVersion(section.version, 10,0, stage='release'):  # noqa: E231
             section.field78_md5 = bytes(data.field78_md5)
-        if LV.isGreaterOrEqVersion(section.version, 14,0):  # noqa: E231
+        if isGreaterOrEqVersion(section.version, 14,0):  # noqa: E231
             section.inlineStg = int(data.inlineStg)
-        if LV.isGreaterOrEqVersion(section.version, 15,0):  # noqa: E231
+        if isGreaterOrEqVersion(section.version, 15,0):  # noqa: E231
             section.field8C = int(data.field8C)
         # Any data added in future versions
         section.field90 = bldata.read()
@@ -3643,23 +3645,23 @@ class LVSR(CompleteBlock):
         data_buf += int(section.field2C).to_bytes(4, byteorder='big')
         data_buf += int(section.field30).to_bytes(4, byteorder='big')
         data_buf += section.viSignature
-        if LV.isGreaterOrEqVersion(section.version, 7,0):  # noqa: E231
+        if isGreaterOrEqVersion(section.version, 7,0):  # noqa: E231
             data_buf += int(section.alignGridFP).to_bytes(4, byteorder='big')
             data_buf += int(section.alignGridBD).to_bytes(4, byteorder='big')
             data_buf += int(section.field4C).to_bytes(2, byteorder='big')
             data_buf += int(section.ctrlIndStyle).to_bytes(2, byteorder='big')
             data_buf += section.field50_md5
-        if LV.isGreaterOrEqVersion(section.version, 8,0):  # noqa: E231
+        if isGreaterOrEqVersion(section.version, 8,0):  # noqa: E231
             if section.libpass_text is not None:
                 pass  # TODO re-compute md5 from pass
             data_buf += section.libpass_md5
             data_buf += int(section.field70).to_bytes(4, byteorder='big')
             data_buf += int(section.field74).to_bytes(4, byteorder='big', signed=True)
-        if LV.isGreaterOrEqVersion(section.version, 10,0, stage='release'):  # noqa: E231
+        if isGreaterOrEqVersion(section.version, 10,0, stage='release'):  # noqa: E231
             data_buf += section.field78_md5
-        if LV.isGreaterOrEqVersion(section.version, 14,0):  # noqa: E231
+        if isGreaterOrEqVersion(section.version, 14,0):  # noqa: E231
             data_buf += int(section.inlineStg).to_bytes(1, byteorder='big')
-        if LV.isGreaterOrEqVersion(section.version, 15,0):  # noqa: E231
+        if isGreaterOrEqVersion(section.version, 15,0):  # noqa: E231
             data_buf += b'\0' * 3
             data_buf += int(section.field8C).to_bytes(4, byteorder='big')
         data_buf += section.field90
@@ -3669,15 +3671,15 @@ class LVSR(CompleteBlock):
         section = self.sections[section_num]
         exp_whole_len = 68
 
-        if LV.isGreaterOrEqVersion(section.version, 7,0):  # noqa: E231
+        if isGreaterOrEqVersion(section.version, 7,0):  # noqa: E231
             exp_whole_len += 28
-        if LV.isGreaterOrEqVersion(section.version, 8,0):  # noqa: E231
+        if isGreaterOrEqVersion(section.version, 8,0):  # noqa: E231
             exp_whole_len += 24
-        if LV.isGreaterOrEqVersion(section.version, 10,0, stage='release'):  # noqa: E231
+        if isGreaterOrEqVersion(section.version, 10,0, stage='release'):  # noqa: E231
             exp_whole_len += 16  # total 136
-        if LV.isGreaterOrEqVersion(section.version, 14,0):  # noqa: E231
+        if isGreaterOrEqVersion(section.version, 14,0):  # noqa: E231
             exp_whole_len += 1  # total 137
-        if LV.isGreaterOrEqVersion(section.version, 15,0):  # noqa: E231
+        if isGreaterOrEqVersion(section.version, 15,0):  # noqa: E231
             exp_whole_len += 3 + 4
         exp_whole_len += len(section.field90)
         return exp_whole_len
@@ -3715,23 +3717,23 @@ class LVSR(CompleteBlock):
                 section.execState = int(subelem.get("State"), 0)
                 section.execPrio = int(subelem.get("Priority"), 0)
                 section.prefExecSyst = int(subelem.get("PrefExecSyst"), 0)
-                section.execFlags = LV.importXMLBitfields(LVinstrument.VI_EXEC_FLAGS, subelem)
+                section.execFlags = importXMLBitfields(LVinstrument.VI_EXEC_FLAGS, subelem)
             elif (subelem.tag == "Execution2"):
-                section.viFlags2 = LV.importXMLBitfields(LVinstrument.VI_FLAGS2, subelem)
+                section.viFlags2 = importXMLBitfields(LVinstrument.VI_FLAGS2, subelem)
             elif (subelem.tag == "ButtonsHidden"):
-                section.buttonsHidden = LV.importXMLBitfields(LVinstrument.VI_BTN_HIDE_FLAGS, subelem)
+                section.buttonsHidden = importXMLBitfields(LVinstrument.VI_BTN_HIDE_FLAGS, subelem)
             elif (subelem.tag == "Instrument"):
                 section.viType = LV.valFromEnumOrIntString(LVinstrument.VI_TYPE, subelem.get("Type"))
                 tmphash = subelem.get("Signature")
                 section.viSignature = bytes.fromhex(tmphash)
-                section.instrState = LV.importXMLBitfields(LVinstrument.VI_IN_ST_FLAGS, subelem)
+                section.instrState = importXMLBitfields(LVinstrument.VI_IN_ST_FLAGS, subelem)
             elif (subelem.tag == "FrontPanel"):
                 section.ctrlIndStyle = int(subelem.get("CtrlIndStyle"), 0)
-                section.frontpFlags = LV.importXMLBitfields(LVinstrument.VI_FP_FLAGS, subelem)
+                section.frontpFlags = importXMLBitfields(LVinstrument.VI_FP_FLAGS, subelem)
             elif (subelem.tag == "Flags0C"):
-                section.field0C = LV.importXMLBitfields(LVinstrument.VI_FLAGS0C, subelem)
+                section.field0C = importXMLBitfields(LVinstrument.VI_FLAGS0C, subelem)
             elif (subelem.tag == "Flags12"):
-                section.field12 = LV.importXMLBitfields(LVinstrument.VI_FLAGS12, subelem)
+                section.field12 = importXMLBitfields(LVinstrument.VI_FLAGS12, subelem)
             elif (subelem.tag == "Unknown"):
                 section.flags10 = int(subelem.get("Flags10"), 0)
                 section.field28 = int(subelem.get("Field28"), 0)
@@ -3784,29 +3786,29 @@ class LVSR(CompleteBlock):
         subelem.set("State", "{:d}".format(section.execState))
         subelem.set("Priority", "{:d}".format(section.execPrio))
         subelem.set("PrefExecSyst", "{:d}".format(section.prefExecSyst))
-        LV.exportXMLBitfields(LVinstrument.VI_EXEC_FLAGS, subelem, section.execFlags,
-                              skip_mask=LVinstrument.VI_EXEC_FLAGS.LibProtected.value)
+        exportXMLBitfields(LVinstrument.VI_EXEC_FLAGS, subelem, section.execFlags,
+                           skip_mask=LVinstrument.VI_EXEC_FLAGS.LibProtected.value)
 
         subelem = ET.SubElement(section_elem, "Execution2")
-        LV.exportXMLBitfields(LVinstrument.VI_FLAGS2, subelem, section.viFlags2)
+        exportXMLBitfields(LVinstrument.VI_FLAGS2, subelem, section.viFlags2)
 
         subelem = ET.SubElement(section_elem, "ButtonsHidden")
-        LV.exportXMLBitfields(LVinstrument.VI_BTN_HIDE_FLAGS, subelem, section.buttonsHidden)
+        exportXMLBitfields(LVinstrument.VI_BTN_HIDE_FLAGS, subelem, section.buttonsHidden)
 
         subelem = ET.SubElement(section_elem, "Instrument")
         subelem.set("Type", "{:s}".format(LV.stringFromValEnumOrInt(LVinstrument.VI_TYPE, section.viType)))
         subelem.set("Signature", section.viSignature.hex())
-        LV.exportXMLBitfields(LVinstrument.VI_IN_ST_FLAGS, subelem, section.instrState)
+        exportXMLBitfields(LVinstrument.VI_IN_ST_FLAGS, subelem, section.instrState)
 
         subelem = ET.SubElement(section_elem, "FrontPanel")
         subelem.set("CtrlIndStyle", "{:d}".format(section.ctrlIndStyle))
-        LV.exportXMLBitfields(LVinstrument.VI_FP_FLAGS, subelem, section.frontpFlags)
+        exportXMLBitfields(LVinstrument.VI_FP_FLAGS, subelem, section.frontpFlags)
 
         subelem = ET.SubElement(section_elem, "Flags0C")
-        LV.exportXMLBitfields(LVinstrument.VI_FLAGS0C, subelem, section.field0C)
+        exportXMLBitfields(LVinstrument.VI_FLAGS0C, subelem, section.field0C)
 
         subelem = ET.SubElement(section_elem, "Flags12")
-        LV.exportXMLBitfields(LVinstrument.VI_FLAGS12, subelem, section.field12)
+        exportXMLBitfields(LVinstrument.VI_FLAGS12, subelem, section.field12)
 
         subelem = ET.SubElement(section_elem, "Unknown")
 
@@ -3867,9 +3869,9 @@ class vers(Block):
         section.version_info = bldata.read(version_info_len)
         comment_len = int.from_bytes(bldata.read(1), byteorder='big', signed=False)
         section.comment = bldata.read(comment_len)
-        if LV.isGreaterOrEqVersion(self.version, 8,6,0) and comment_len != 0:  # noqa: E231
-            LV.eprint("Warning: Block {} section {} comment length is {} instead of {}"
-                      .format(self.ident, section_num, comment_len, 0))
+        if isGreaterOrEqVersion(self.version, 8,6,0) and comment_len != 0:  # noqa: E231
+            eprint("Warning: Block {} section {} comment length is {} instead of {}"
+                   .format(self.ident, section_num, comment_len, 0))
 
     def updateSectionData(self, section_num=None):
         if section_num is None:
@@ -4382,7 +4384,7 @@ class BDPW(Block):
         Tested not to be there in LV7.1, is there in LV8.6b7
         """
         ver = self.vi.getFileVersion()
-        return LV.isGreaterOrEqVersion(ver, 8,0,0)  # noqa: E231
+        return isGreaterOrEqVersion(ver, 8,0,0)  # noqa: E231
 
     def parseRSRCData(self, section_num, bldata):
         section = self.sections[section_num]
@@ -4411,8 +4413,8 @@ class BDPW(Block):
 
         exp_whole_len = self.expectedRSRCSize(section_num)
         if (len(data_buf) != exp_whole_len):
-            LV.eprint("{:s}: Warning: Block {} section {} generated binary data of size {:d}, expected {:d}"
-                      .format(self.vi.src_fname, self.ident, section_num, len(data_buf), exp_whole_len))
+            eprint("{:s}: Warning: Block {} section {} generated binary data of size {:d}, expected {:d}"
+                   .format(self.vi.src_fname, self.ident, section_num, len(data_buf), exp_whole_len))
 
         self.setData(data_buf, section_num=section_num)
 
@@ -4428,8 +4430,8 @@ class BDPW(Block):
             self.recalculateHash1(section_num=snum, store=False)  # this is needed to find salt
             self.recognizePassword(section_num=snum)
         except Exception as e:
-            LV.eprint("{:s}: Warning: Block {} section {} could not be fully parametrized: {}"
-                      .format(self.vi.src_fname, self.ident, snum, str(e)))
+            eprint("{:s}: Warning: Block {} section {} could not be fully parametrized: {}"
+                   .format(self.vi.src_fname, self.ident, snum, str(e)))
             pass
 
         subelem = ET.SubElement(section_elem, "Password")
@@ -4513,13 +4515,13 @@ class BDPW(Block):
         salt = b''
         salt_source = "None"
         ver = self.vi.getFileVersion()
-        if not LV.isGreaterOrEqVersion(ver, 1,0):  # noqa: E231
+        if not isGreaterOrEqVersion(ver, 1,0):  # noqa: E231
             if (self.po.verbose > 0):
-                LV.eprint("{:s}: Warning: No version block found; assuming oldest format, with empty password salt"
-                          .format(self.vi.src_fname))
+                eprint("{:s}: Warning: No version block found; assuming oldest format, with empty password salt"
+                       .format(self.vi.src_fname))
             section.salt = salt
             return salt
-        if LV.isGreaterOrEqVersion(ver, 12,0):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 12,0):  # noqa: E231
             # Figure out the salt
             salt_td_flat_idx = None
             VCTP = self.vi.get_or_raise('VCTP')
@@ -4877,7 +4879,7 @@ class PRT(CompleteBlock):
         section.field90 = b''
         # The size is 128 bytes for LV7.0 and older, and LV 14.0 and newer; but for some
         # versions between, there are additional 24 bytes in this block, zero-filled
-        if LV.isGreaterOrEqVersion(ver, 10,0,0,4):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 10,0,0,4):  # noqa: E231
             section.field90 = bldata.read(24)
 
     def prepareRSRCData(self, section_num):
@@ -4917,7 +4919,7 @@ class PRT(CompleteBlock):
         data_buf += int(section.field84).to_bytes(4, byteorder='big', signed=False)
         data_buf += int(section.field88).to_bytes(4, byteorder='big', signed=False)
         data_buf += int(section.field8C).to_bytes(4, byteorder='big', signed=False)
-        if LV.isGreaterOrEqVersion(ver, 10,0,0,4):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 10,0,0,4):  # noqa: E231
             data_buf += section.field90
         return data_buf
 
@@ -5211,8 +5213,8 @@ class HeapVerb(CompleteBlock):
             tot_len += entry_len
 
         if parentNode is not None:
-            LV.eprint("{}: Warning: In block {}, heap did not closed all tags"
-                      .format(self.vi.src_fname, self.ident))
+            eprint("{}: Warning: In block {}, heap did not closed all tags"
+                   .format(self.vi.src_fname, self.ident))
         pass
 
     def prepareRSRCData(self, section_num):
@@ -5283,8 +5285,8 @@ class HeapVerb(CompleteBlock):
             elif scopeInfo == LVheap.NODE_SCOPE.TagClose:
                 elem = parent_elems.pop()
                 if elem.tag != tagName:
-                    LV.eprint("{}: Warning: In block {}, closing tag {} instead of {}"
-                              .format(self.vi.src_fname, self.ident, tagName, elem.tag))
+                    eprint("{}: Warning: In block {}, closing tag {} instead of {}"
+                           .format(self.vi.src_fname, self.ident, tagName, elem.tag))
             else:
                 # Having two root items would crash here. And that's good, we can't have two roots.
                 elem = ET.SubElement(parent_elems[-1], tagName)
@@ -5295,8 +5297,8 @@ class HeapVerb(CompleteBlock):
                 parent_elems.append(elem)
 
         if len(parent_elems) > 0:
-            LV.eprint("{}: Warning: In block {}, heap structure is not a valid XML tree"
-                      .format(self.vi.src_fname, self.ident))
+            eprint("{}: Warning: In block {}, heap structure is not a valid XML tree"
+                   .format(self.vi.src_fname, self.ident))
         pass
 
     def initWithXMLLate(self):
@@ -5656,7 +5658,7 @@ class UCRF(VarCodingBlock):
                     snum_str = 'm' + str(-snum)
                 fname_base = "{:s}_{:s}".format(fname_base, snum_str)
         else:
-            pretty_ident = LV.getPrettyStrFromRsrcType(self.ident)
+            pretty_ident = getPrettyStrFromRsrcType(self.ident)
             if len(self.sections) == 1:
                 fname_base = "{:s}_{:s}".format(fname_base, pretty_ident)
             else:
@@ -5750,8 +5752,8 @@ class TypeDescListBase(CompleteBlock):
             self.appendPrintMapEntry(section, bldata.tell(), bldata.tell()-pos, 1,
                                      "TypeDesc[{}].{}.Header".format(td_idx, obj_type_str))
         if obj_len < 4:
-            LV.eprint("{:s}: Warning: TypeDesc {:d} type 0x{:02x} data size {:d} too small to be valid"
-                      .format(self.vi.src_fname, len(section.content), obj_type, obj_len))
+            eprint("{:s}: Warning: TypeDesc {:d} type 0x{:02x} data size {:d} too small to be valid"
+                   .format(self.vi.src_fname, len(section.content), obj_type, obj_len))
             obj_type = LVdatatype.TD_FULL_TYPE.Void
         obj = LVdatatype.newTDObject(self.vi, blockref, len(section.content), obj_flags, obj_type, self.po)
 
@@ -5795,7 +5797,7 @@ class TypeDescListBase(CompleteBlock):
     def initWithXMLTypeDesc(self, section, td_elem):
         obj_idx = len(section.content)
         obj_type = LV.valFromEnumOrIntString(LVdatatype.TD_FULL_TYPE, td_elem.get("Type"))
-        obj_flags = LV.importXMLBitfields(LVdatatype.TYPEDESC_FLAGS, td_elem)
+        obj_flags = importXMLBitfields(LVdatatype.TYPEDESC_FLAGS, td_elem)
         blockref = (self.ident, section.start.section_idx,)
         obj = LVdatatype.newTDObject(self.vi, blockref, obj_idx, obj_flags, obj_type, self.po)
         clientTD = SimpleNamespace()
@@ -5895,8 +5897,8 @@ class TypeDescListBase(CompleteBlock):
         for i, val in enumerate(section.topLevel):
             if val >= len(section.content):
                 if (self.po.verbose > 1):
-                    LV.eprint("{:s}: Warning: TopLevel index {:d} exceeds flat TD count {:d}"
-                              .format(self.vi.src_fname, i, len(section.content)))
+                    eprint("{:s}: Warning: TopLevel index {:d} exceeds flat TD count {:d}"
+                           .format(self.vi.src_fname, i, len(section.content)))
                 ret = False
         return ret
 
@@ -6213,7 +6215,7 @@ class VICD(CompleteBlock):
         section = self.sections[section_num]
         ver = self.vi.getFileVersion()
         # verified NONE in 5.1, ZLIB in 8.6
-        if LV.isGreaterOrEqVersion(ver, 8,0,0,3):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 8,0,0,3):  # noqa: E231
             section.block_coding = BLOCK_CODING.ZLIB
         else:
             section.block_coding = BLOCK_CODING.NONE
@@ -6240,7 +6242,7 @@ class VICD(CompleteBlock):
     def parseRSRCSectionHead(self, section, section_num, bldata):
         ver = self.vi.getFileVersion()
 
-        if LV.isGreaterOrEqVersion(ver, 12,0,0,0):  # noqa: E231  # Should be False for LV 11,0,0,4, True for 14,0,0,3
+        if isGreaterOrEqVersion(ver, 12,0,0,0):  # noqa: E231  # Should be False for LV 11,0,0,4, True for 14,0,0,3
             initProcOffset = bldata.read(4)
             self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "Head.initProcOffset")
             section.codeID = bldata.read(4)
@@ -6269,7 +6271,7 @@ class VICD(CompleteBlock):
             self.appendPrintMapEntry(section, bldata.tell(), archDependLen, 1, "Head.codeEndOffset")
             section.signatureName = int.from_bytes(bldata.read(4), byteorder='big', signed=False)
             self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "Head.signatureName")
-        elif LV.isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231  # Lowest version tested with this is LV 6,0,0,2
+        elif isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231  # Lowest version tested with this is LV 6,0,0,2
             initProcOffset = bldata.read(4)
             self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "Head.initProcOffset")
             section.codeID = bldata.read(4)
@@ -6325,7 +6327,7 @@ class VICD(CompleteBlock):
         ver = self.vi.getFileVersion()
         data_buf = b''
 
-        if LV.isGreaterOrEqVersion(ver, 12,0,0,0):  # noqa: E231  # Should be False for LV 11,0,0,4, True for 14,0,0,3
+        if isGreaterOrEqVersion(ver, 12,0,0,0):  # noqa: E231  # Should be False for LV 11,0,0,4, True for 14,0,0,3
             data_buf += int(section.initProcOffset).to_bytes(4, byteorder=archEndianness, signed=False)
             data_buf += section.codeID[:4]
             data_buf += int(section.pTabOffset).to_bytes(4, byteorder=archEndianness, signed=False)
@@ -6337,7 +6339,7 @@ class VICD(CompleteBlock):
             data_buf += int(section.hostCodeEntryVI).to_bytes(4, byteorder=archEndianness, signed=False)
             data_buf += int(section.codeEndOffset).to_bytes(archDependLen, byteorder=archEndianness, signed=False)
             data_buf += int(section.signatureName).to_bytes(4, byteorder='big', signed=False)
-        elif LV.isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231
+        elif isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231
             data_buf += int(section.initProcOffset).to_bytes(4, byteorder=archEndianness, signed=False)
             data_buf += section.codeID[:4]
             data_buf += int(section.pTabOffset).to_bytes(4, byteorder=archEndianness, signed=False)
@@ -6361,7 +6363,7 @@ class VICD(CompleteBlock):
         archDependLen = 8 if self.isX64(section_num) else 4
 
         exp_whole_len = 0
-        if LV.isGreaterOrEqVersion(ver, 12,0,0,0):  # noqa: E231  # Should be False for LV 11,0,0,4, True for 14,0,0,3
+        if isGreaterOrEqVersion(ver, 12,0,0,0):  # noqa: E231  # Should be False for LV 11,0,0,4, True for 14,0,0,3
             exp_whole_len += 4 + 4 + 4 + 4 + 4 + 4 + 4 + 4 + 4 + archDependLen + 4
         else:  # Lowest version tested with this is LV 6,0,0,2
             exp_whole_len += 4 + 4 + 4 + 4 + 4 + 4 + 4 + archDependLen + 4 + 4
@@ -6371,14 +6373,14 @@ class VICD(CompleteBlock):
         ver = self.vi.getFileVersion()
 
         # Oldest versions have no footer
-        if LV.isSmallerVersion(ver, 5,0,0,0):  # noqa: E231
+        if isSmallerVersion(ver, 5,0,0,0):  # noqa: E231
             return
 
         section.endVerifier = bldata.read(4)
         self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "Foot.endVerifier")
         section.endProp1 = int.from_bytes(bldata.read(4), byteorder='big', signed=False)
 
-        if LV.isGreaterOrEqVersion(ver, 7,0,0,0):  # noqa: E231  # Should be False for LV 6,0,0,2, True for 7,1,0,3
+        if isGreaterOrEqVersion(ver, 7,0,0,0):  # noqa: E231  # Should be False for LV 6,0,0,2, True for 7,1,0,3
             # TODO inconsistency - signatureName doesn't have arch-dependant size
             section.endSignatureName = int.from_bytes(bldata.read(archDependLen), byteorder='big', signed=False)
             self.appendPrintMapEntry(section, bldata.tell(), archDependLen, 1, "Foot.endSignatureName")
@@ -6389,7 +6391,7 @@ class VICD(CompleteBlock):
         section.endCodeEndOffset = int.from_bytes(bldata.read(4), byteorder=archEndianness, signed=False)
         self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "Foot.endCodeEndOffset")
 
-        if LV.isGreaterOrEqVersion(ver, 13,0,0,0):  # noqa: E231  # Should be False for 12,0,0,4, True for 14,0,0,3
+        if isGreaterOrEqVersion(ver, 13,0,0,0):  # noqa: E231  # Should be False for 12,0,0,4, True for 14,0,0,3
             # TODO maybe for 64-bit arch it's a missing part of endCodeEndOffset?
             section.endProp5 = int.from_bytes(bldata.read(4), byteorder='big', signed=False)
             self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "Foot.endProp5")
@@ -6400,19 +6402,19 @@ class VICD(CompleteBlock):
         data_buf = b''
 
         # Oldest versions have no footer
-        if LV.isSmallerVersion(ver, 5,0,0,0):  # noqa: E231
+        if isSmallerVersion(ver, 5,0,0,0):  # noqa: E231
             return data_buf
 
         data_buf += section.endVerifier[:4]
         data_buf += int(section.endProp1).to_bytes(4, byteorder='big', signed=False)
 
-        if LV.isGreaterOrEqVersion(ver, 7,0,0,0):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 7,0,0,0):  # noqa: E231
             data_buf += int(section.endSignatureName).to_bytes(archDependLen, byteorder='big', signed=False)
             data_buf += int(section.endLocalLVRTCodeBlocks).to_bytes(archDependLen, byteorder='big', signed=False)
 
         data_buf += int(section.endCodeEndOffset).to_bytes(4, byteorder=archEndianness, signed=False)
 
-        if LV.isGreaterOrEqVersion(ver, 13,0,0,0):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 13,0,0,0):  # noqa: E231
             data_buf += int(section.endProp5).to_bytes(4, byteorder='big', signed=False)
         return data_buf
 
@@ -6422,10 +6424,10 @@ class VICD(CompleteBlock):
 
         exp_whole_len = 0
         exp_whole_len += 4 + 4
-        if LV.isGreaterOrEqVersion(ver, 7,0,0,0):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 7,0,0,0):  # noqa: E231
             exp_whole_len += archDependLen + archDependLen
         exp_whole_len += 4
-        if LV.isGreaterOrEqVersion(ver, 13,0,0,0):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 13,0,0,0):  # noqa: E231
             exp_whole_len += 4
         return exp_whole_len
 
@@ -6459,10 +6461,10 @@ class VICD(CompleteBlock):
             self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "Patch[{}].Ident".format(pidx))
 
             badOffset = False
-            if LV.isGreaterOrEqVersion(ver, 14,0,0,0):  # noqa: E231
+            if isGreaterOrEqVersion(ver, 14,0,0,0):  # noqa: E231
                 if patch.offs >= codeTotLen and patch.ident != 0x20000:
                     badOffset = True
-            elif LV.isGreaterOrEqVersion(ver, 6,0,0,0):  # noqa: E231
+            elif isGreaterOrEqVersion(ver, 6,0,0,0):  # noqa: E231
                 # Confirmed for LV6.0 and LV8.6 (though the format inside is different below 8.6)
                 if patch.offs >= codeTotLen and patch.ident != 0xffffffff:
                     badOffset = True
@@ -6474,8 +6476,8 @@ class VICD(CompleteBlock):
             patch.relocs = []
             section.patches.append(patch)
 
-            if (LV.isGreaterOrEqVersion(ver, 10,0,0,0) and (patch.ident == 0x20000 or patch.ident == 0x20007)) or \
-               (LV.isGreaterOrEqVersion(ver,  8,6,0,0) and (patch.ident == 0xffffffff)):  # noqa: E231
+            if (isGreaterOrEqVersion(ver, 10,0,0,0) and (patch.ident == 0x20000 or patch.ident == 0x20007)) or \
+               (isGreaterOrEqVersion(ver,  8,6,0,0) and (patch.ident == 0xffffffff)):  # noqa: E231
                 patch.field2 = int.from_bytes(bldata.read(4), byteorder=archEndianness, signed=False)
                 self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "Patch[{}].Field2".format(pidx))
                 bucketCount = int.from_bytes(bldata.read(2), byteorder=archEndianness, signed=False)
@@ -6493,7 +6495,7 @@ class VICD(CompleteBlock):
                 uneven_len = patchLen % 4  # Read padding
                 if uneven_len > 0:
                     bldata.read(4 - uneven_len)
-            elif LV.isGreaterOrEqVersion(ver, 6,0,0,0) and (patch.ident == 0xffffffff):  # noqa: E231
+            elif isGreaterOrEqVersion(ver, 6,0,0,0) and (patch.ident == 0xffffffff):  # noqa: E231
                 raise NotImplementedError("No XML export made for LV6 relocations")
             else:
                 pass
@@ -6520,8 +6522,8 @@ class VICD(CompleteBlock):
         for patch in section.patches:
             data_buf += int(patch.offs).to_bytes(4, byteorder=archEndianness, signed=False)
             data_buf += int(patch.ident).to_bytes(4, byteorder=archEndianness, signed=False)
-            if (LV.isGreaterOrEqVersion(ver, 10,0,0,0) and (patch.ident == 0x20000 or patch.ident == 0x20007)) or \
-               (LV.isGreaterOrEqVersion(ver,  8,6,0,0) and (patch.ident == 0xffffffff)):  # noqa: E231
+            if (isGreaterOrEqVersion(ver, 10,0,0,0) and (patch.ident == 0x20000 or patch.ident == 0x20007)) or \
+               (isGreaterOrEqVersion(ver,  8,6,0,0) and (patch.ident == 0xffffffff)):  # noqa: E231
                 data_buf += int(patch.field2).to_bytes(4, byteorder=archEndianness, signed=False)
                 relocs = patch.relocs  # no sorted() - preserve original order
                 bucket_idx = 0
@@ -6542,7 +6544,7 @@ class VICD(CompleteBlock):
                     bucket_idx += 1
                 data_buf += int(bucket_idx).to_bytes(2, byteorder=archEndianness, signed=False)
                 data_buf += bucket_buf
-            elif LV.isGreaterOrEqVersion(ver, 6,0,0,0) and (patch.ident == 0xffffffff):  # noqa: E231
+            elif isGreaterOrEqVersion(ver, 6,0,0,0) and (patch.ident == 0xffffffff):  # noqa: E231
                 raise NotImplementedError("No bin prepare made for LV6 relocations")
 
         patchesTotLen = section.codeEndOffset - section.pTabOffset
@@ -6634,8 +6636,8 @@ class VICD(CompleteBlock):
                 import sys
                 import traceback
                 traceback.print_exc(file=sys.stdout)
-            LV.eprint("{:s}: Warning: Block {} section {} patches parse exception: {}."
-                      .format(self.vi.src_fname, self.ident, section_num, str(e)))
+            eprint("{:s}: Warning: Block {} section {} patches parse exception: {}."
+                   .format(self.vi.src_fname, self.ident, section_num, str(e)))
             self.parseRSRCSectionRawPatches(section, section_num, patchesPos, archEndianness, archDependLen, bldata)
         self.appendPrintMapEntry(section, bldata.tell(), bldata.tell() - patchesPos, 1, "Patches")
 
@@ -6821,15 +6823,15 @@ class VICD(CompleteBlock):
         ver = self.vi.getFileVersion()
         subelem = ET.SubElement(section_elem, "General")
 
-        subelem.set("CodeID", LV.getPrettyStrFromRsrcType(section.codeID))
+        subelem.set("CodeID", getPrettyStrFromRsrcType(section.codeID))
         subelem.set("CodeFlags", "0x{:X}".format(section.codeFlags))
         subelem.set("Version", "0x{:X}".format(section.version))
         subelem.set("CompilerOptimizationLevel", "{:d}".format(section.compilerOptimizationLevel))
-        if LV.isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231
-            subelem.set("Verifier", LV.getPrettyStrFromRsrcType(section.verifier))
+        if isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231
+            subelem.set("Verifier", getPrettyStrFromRsrcType(section.verifier))
 
-        if LV.isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231
-            subelem.set("EndVerifier", LV.getPrettyStrFromRsrcType(section.endVerifier))
+        if isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231
+            subelem.set("EndVerifier", getPrettyStrFromRsrcType(section.endVerifier))
             subelem.set("EndProp1", "{:d}".format(section.endProp1))
             subelem.set("EndSignatureName", "{:d}".format(section.endSignatureName))
             subelem.set("EndLocalLVRTCodeBlocks", "{:d}".format(section.endLocalLVRTCodeBlocks))
@@ -6846,7 +6848,7 @@ class VICD(CompleteBlock):
                 pass  # Items parsed somewhere else
             elif (subelem.tag == "General"):
                 tmp = subelem.get("CodeID")
-                section.codeID = LV.getRsrcTypeFromPrettyStr(tmp)
+                section.codeID = getRsrcTypeFromPrettyStr(tmp)
                 tmp = subelem.get("CodeFlags")
                 section.codeFlags = int(tmp, 0)
                 tmp = subelem.get("Version")
@@ -6855,11 +6857,11 @@ class VICD(CompleteBlock):
                 section.compilerOptimizationLevel = int(tmp, 0)
                 tmp = subelem.get("Verifier")
                 if tmp is not None:
-                    section.verifier = LV.getRsrcTypeFromPrettyStr(tmp)
+                    section.verifier = getRsrcTypeFromPrettyStr(tmp)
 
                 tmp = subelem.get("EndVerifier")
                 if tmp is not None:
-                    section.endVerifier = LV.getRsrcTypeFromPrettyStr(tmp)
+                    section.endVerifier = getRsrcTypeFromPrettyStr(tmp)
                 tmp = subelem.get("EndProp1")
                 if tmp is not None:
                     section.endProp1 = int(tmp, 0)
@@ -6957,29 +6959,29 @@ class VICD(CompleteBlock):
         ret = True
         if section.initProcOffset >= section.pTabOffset:
             if (self.po.verbose > 1):
-                LV.eprint("{:s}: Warning: InitProcOffset 0x{:X} exceeds PTabOffset 0x{:X}"
-                          .format(self.vi.src_fname, section.initProcOffset, section.pTabOffset))
+                eprint("{:s}: Warning: InitProcOffset 0x{:X} exceeds PTabOffset 0x{:X}"
+                       .format(self.vi.src_fname, section.initProcOffset, section.pTabOffset))
             ret = False
-        if LV.isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231
             if section.pTabOffset >= section.codeEndOffset:
                 if (self.po.verbose > 1):
-                    LV.eprint("{:s}: Warning: PTabOffset 0x{:X} exceeds CodeEndOffset 0x{:X}"
-                              .format(self.vi.src_fname, section.pTabOffset, section.codeEndOffset))
+                    eprint("{:s}: Warning: PTabOffset 0x{:X} exceeds CodeEndOffset 0x{:X}"
+                           .format(self.vi.src_fname, section.pTabOffset, section.codeEndOffset))
                 ret = False
             if section.codeEndOffset != section.endCodeEndOffset:
                 if (self.po.verbose > 1):
-                    LV.eprint("{:s}: Warning: Copies of CodeEndOffset are different (0x{:X} and 0x{:X})"
-                              .format(self.vi.src_fname, section.codeEndOffset, section.endCodeEndOffset))
+                    eprint("{:s}: Warning: Copies of CodeEndOffset are different (0x{:X} and 0x{:X})"
+                           .format(self.vi.src_fname, section.codeEndOffset, section.endCodeEndOffset))
                 ret = False
             if section.verifier not in (b'code',):
                 if (self.po.verbose > 1):
-                    LV.eprint("{:s}: Warning: Verifier property {} is not known"
-                              .format(self.vi.src_fname, section.verifier))
+                    eprint("{:s}: Warning: Verifier property {} is not known"
+                           .format(self.vi.src_fname, section.verifier))
                 ret = False
             if section.endVerifier not in (b'CODE',):
                 if (self.po.verbose > 1):
-                    LV.eprint("{:s}: Warning: EndVerifier property {} is not known"
-                              .format(self.vi.src_fname, section.endVerifier))
+                    eprint("{:s}: Warning: EndVerifier property {} is not known"
+                           .format(self.vi.src_fname, section.endVerifier))
                 ret = False
         else:  # Older versions lack many header fields
             pass
@@ -7022,7 +7024,7 @@ class VITS(CompleteBlock):
         section.endianness = 'big'
 
         # Get count of tags; endianness was wrong in some versions
-        if LV.isGreaterOrEqVersion(ver, 6,1,0,4):  # noqa: E231
+        if isGreaterOrEqVersion(ver, 6,1,0,4):  # noqa: E231
             count = int.from_bytes(bldata.read(4), byteorder=section.endianness, signed=False)
         else:
             # We can't be sure whether the enianness in this version is correct or not. We have to check that
@@ -7041,7 +7043,7 @@ class VITS(CompleteBlock):
             val.name = LV.readLStr(bldata, 1, self.po)
             self.appendPrintMapEntry(section, bldata.tell(), 4+len(val.name), 1,
                                      "TagObject[{}].Name".format(len(section.content)))
-            if LV.isSmallerVersion(ver, 6,5,0,2):  # noqa: E231
+            if isSmallerVersion(ver, 6,5,0,2):  # noqa: E231
                 bldata.read(4)
             obj_pos = bldata.tell()
             val.obj = LVdatafill.newDataFillObject(self.vi, blockref, LVdatatype.TD_FULL_TYPE.LVVariant, None, self.po)
@@ -7063,7 +7065,7 @@ class VITS(CompleteBlock):
         data_buf += len(section.content).to_bytes(4, byteorder=section.endianness, signed=False)
         for val in section.content:
             data_buf += LV.prepareLStr(val.name, 1, self.po)
-            if LV.isSmallerVersion(ver, 6,5,0,2):  # noqa: E231
+            if isSmallerVersion(ver, 6,5,0,2):  # noqa: E231
                 data_buf += (b'\0' * 4)
             data_buf += val.obj.prepareRSRCData()
         return data_buf

--- a/pylabview/LVblock.py
+++ b/pylabview/LVblock.py
@@ -12,6 +12,7 @@ Classes for interpreting content of specific block types within RSRC files.
 # For a copy, see <https://opensource.org/licenses/MIT>.
 
 import enum
+import struct
 import re
 import io
 import os
@@ -22,10 +23,10 @@ from hashlib import md5
 from types import SimpleNamespace
 from ctypes import *
 
-from pylabview.LVmisc import *
+import pylabview.LVmisc as LV
 import pylabview.LVxml as ET
-from pylabview.LVdatatype import *
-from pylabview.LVinstrument import *
+import pylabview.LVdatatype as LVdatatype
+import pylabview.LVinstrument as LVinstrument
 import pylabview.LVclasses as LVclasses
 import pylabview.LVdatafill as LVdatafill
 import pylabview.LVlinkinfo as LVlinkinfo
@@ -40,7 +41,7 @@ class BLOCK_CODING(enum.Enum):
     XOR = 3
 
 
-class BlockHeader(RSRCStructure):
+class BlockHeader(LV.RSRCStructure):
     _fields_ = [('ident', c_ubyte * 4),	 # 0 4-byte block identifier
                 ('count', c_uint32),	 # 4 Amount of sections for that block
                 ('offset', c_uint32),	 # 8 Offset to the array of BlockSectionStart structs
@@ -55,7 +56,7 @@ class BlockHeader(RSRCStructure):
         return ret
 
 
-class BlockSectionStart(RSRCStructure):
+class BlockSectionStart(LV.RSRCStructure):
     """ Info Header of a section
 
         Stores location of its data, but also name offset and index
@@ -77,7 +78,7 @@ class BlockSectionStart(RSRCStructure):
         return ret
 
 
-class BlockSectionData(RSRCStructure):
+class BlockSectionData(LV.RSRCStructure):
     """ Header for raw data of a section within a block
 
         Stores only size of the raw data which follows.
@@ -161,7 +162,7 @@ class Block(object):
         section_num = section.start.section_idx
         if self.po.print_map == "RSRC" and section.block_coding == BLOCK_CODING.NONE \
            or self.po.print_map == type(self).__name__:
-            pretty_ident = getPrettyStrFromRsrcType(self.ident)
+            pretty_ident = LV.getPrettyStrFromRsrcType(self.ident)
             if self.po.print_map == "RSRC":
                 print_map_base = self.getDataPosInContainer(section_num=section_num)
             else:
@@ -193,7 +194,7 @@ class Block(object):
             self.vi.binflsthead.blockinfo_offset + \
             self.header.offset
         if self.po.print_map == "RSRC":
-            pretty_ident = getPrettyStrFromRsrcType(self.ident)
+            pretty_ident = LV.getPrettyStrFromRsrcType(self.ident)
 
         fh = self.vi.rsrc_fh
         fh.seek(start_pos)
@@ -231,7 +232,7 @@ class Block(object):
         """
         fh = self.vi.rsrc_fh
         if self.po.print_map == "RSRC":
-            pretty_ident = getPrettyStrFromRsrcType(self.ident)
+            pretty_ident = LV.getPrettyStrFromRsrcType(self.ident)
         # After BlockSectionStart list, there is Block Section Names list; only some sections have a name
         names_start = self.vi.getPositionOfBlockSectionNames()
         names_end = self.vi.getPositionOfBlockInfoEnd()
@@ -290,7 +291,7 @@ class Block(object):
 
         At the point it is executed, other blocks and sections are inaccessible.
         """
-        self.ident = getRsrcTypeFromPrettyStr(block_elem.tag)
+        self.ident = LV.getRsrcTypeFromPrettyStr(block_elem.tag)
         self.header = BlockHeader(self.po)
         self.header.ident = (c_ubyte * 4).from_buffer_copy(self.ident)
         self.active_section_num = None
@@ -320,8 +321,8 @@ class Block(object):
                     section.name_obj = LVclasses.LVPath0(self.vi, blockref, self.po)
                     section.name_obj.initWithXML(subelem)
                     if section.name_text is not None:
-                        eprint("{:s}: Warning: Block {} section {} has both 'Name' attrib and 'NameObject' tag."
-                               .format(self.vi.src_fname, self.ident, i))
+                        LV.eprint("{:s}: Warning: Block {} section {} has both 'Name' attrib and 'NameObject' tag."
+                                  .format(self.vi.src_fname, self.ident, i))
                     section.name_text = section.name_obj.prepareRSRCData()
                     break
 
@@ -408,7 +409,7 @@ class Block(object):
 
         fh = self.vi.rsrc_fh
         if self.po.print_map == "RSRC":
-            pretty_ident = getPrettyStrFromRsrcType(self.ident)
+            pretty_ident = LV.getPrettyStrFromRsrcType(self.ident)
         for snum, section in sorted(self.sections.items()):
             if snum >= section_count:
                 break
@@ -639,7 +640,7 @@ class Block(object):
                 raise IOError("Unable to decompress block {} section {}: "
                               "uncompress-size-error - size: {} - uncompress-size: {}"
                               .format(self.ident, section_num, size, usize))
-            data = io.BytesIO(zcomp_zeromsk8_decompress(data.read(size), usize))
+            data = io.BytesIO(LV.zcomp_zeromsk8_decompress(data.read(size), usize))
         elif use_coding == BLOCK_CODING.ZLIB:
             size = len(raw_data_section) - 4
             if size < 2:
@@ -656,7 +657,7 @@ class Block(object):
         elif use_coding == BLOCK_CODING.XOR:
             size = len(raw_data_section)
             usize = size
-            data = io.BytesIO(crypto_xor8320_decrypt(data.read(size)))
+            data = io.BytesIO(LV.crypto_xor8320_decrypt(data.read(size)))
         else:
             raise ValueError("Unsupported compression type")
         section = self.sections[section_num]
@@ -681,13 +682,13 @@ class Block(object):
         elif use_coding == BLOCK_CODING.COMP:
             size = len(data_buf)
             raw_data_section = int(size).to_bytes(4, byteorder='big')
-            raw_data_section += zcomp_zeromsk8_compress(data_buf)
+            raw_data_section += LV.zcomp_zeromsk8_compress(data_buf)
         elif use_coding == BLOCK_CODING.ZLIB:
             size = len(data_buf)
             raw_data_section = int(size).to_bytes(4, byteorder='big')
             raw_data_section += zlib.compress(data_buf)
         elif use_coding == BLOCK_CODING.XOR:
-            raw_data_section = crypto_xor8320_encrypt(data_buf)
+            raw_data_section = LV.crypto_xor8320_encrypt(data_buf)
         else:
             raise ValueError("Unsupported compression type")
 
@@ -731,7 +732,7 @@ class Block(object):
 
             if section.name_text is not None:
                 section.start.name_offset = len(section_names)
-                section_names.extend( preparePStr(section.name_text, 1, self.po) )  # noqa: E201,E202
+                section_names.extend( LV.preparePStr(section.name_text, 1, self.po) )  # noqa: E201,E202
             else:
                 section.start.name_offset = 0xFFFFFFFF
         pass
@@ -791,7 +792,7 @@ class Block(object):
     def exportFilesBase(self, snum, section):
         """ Prepare a base for file names of any files created by data export
         """
-        pretty_ident = getPrettyStrFromRsrcType(self.ident)
+        pretty_ident = LV.getPrettyStrFromRsrcType(self.ident)
         block_fpath = os.path.dirname(self.po.xml)
 
         fname_base = self.po.filebase
@@ -829,7 +830,7 @@ class Block(object):
         """
         from pylabview.LVrsrcontainer import FILE_FMT_TYPE
         ver = self.vi.getFileVersion()
-        pretty_ident = getPrettyStrFromRsrcType(self.ident)
+        pretty_ident = LV.getPrettyStrFromRsrcType(self.ident)
 
         elem = ET.Element(pretty_ident)
         if len(self.full_name) > 0:
@@ -839,7 +840,7 @@ class Block(object):
             section_elem = ET.SubElement(elem, "Section")
             section_elem.set("Index", str(snum))
 
-            if self.vi.ftype == FILE_FMT_TYPE.LLB or isSmallerVersion(ver, 8,0,0):  # noqa: E231
+            if self.vi.ftype == FILE_FMT_TYPE.LLB or LV.isSmallerVersion(ver, 8,0,0):  # noqa: E231
                 # Vefied to be non-zero in LV7.1 files, is zero in LV8.6 files
                 block_int5 = section.start.int5
             else:
@@ -972,12 +973,12 @@ class CompleteBlock(Block):
                 import sys
                 import traceback
                 traceback.print_exc(file=sys.stdout)
-            eprint("{:s}: Warning: Block {} section {} parse exception: {}."
-                   .format(self.vi.src_fname, self.ident, section_num, str(e)))
+            LV.eprint("{:s}: Warning: Block {} section {} parse exception: {}."
+                      .format(self.vi.src_fname, self.ident, section_num, str(e)))
         if bldata.tell() < totlen:
             section.parse_failed = True
-            eprint("{:s}: Warning: Block {} section {} size is {} and does not match parsed size {}"
-                   .format(self.vi.src_fname, self.ident, section_num, totlen, bldata.tell()))
+            LV.eprint("{:s}: Warning: Block {} section {} size is {} and does not match parsed size {}"
+                      .format(self.vi.src_fname, self.ident, section_num, totlen, bldata.tell()))
         if section.parse_failed:
             bldata.seek(startpos)
             Block.parseRSRCData(self, section_num, bldata)
@@ -998,8 +999,8 @@ class CompleteBlock(Block):
 
         # Do not re-create raw data if parsing failed and we still have the original
         if (section.parse_failed and self.hasRawData(section_num)):
-            eprint("{:s}: Warning: Block {} section {} left in original raw form, without re-building"
-                   .format(self.vi.src_fname, self.ident, section_num))
+            LV.eprint("{:s}: Warning: Block {} section {} left in original raw form, without re-building"
+                      .format(self.vi.src_fname, self.ident, section_num))
             return
 
         data_buf = b''
@@ -1011,8 +1012,8 @@ class CompleteBlock(Block):
                 import sys
                 import traceback
                 traceback.print_exc(file=sys.stdout)
-            eprint("{:s}: Warning: Block {} section {} binary prepare exception: {}."
-                   .format(self.vi.src_fname, self.ident, section_num, str(e)))
+            LV.eprint("{:s}: Warning: Block {} section {} binary prepare exception: {}."
+                      .format(self.vi.src_fname, self.ident, section_num, str(e)))
 
         # Do not re-create raw data if parsing failed and we still have the original
         if section.parse_failed:
@@ -1020,8 +1021,8 @@ class CompleteBlock(Block):
                 raise RuntimeError("Block {} section {} could not prepare binary data"
                                    .format(self.ident, section_num))
             else:
-                eprint("{:s}: Warning: Block {} section {} left in original raw form, without re-building"
-                       .format(self.vi.src_fname, self.ident, section_num))
+                LV.eprint("{:s}: Warning: Block {} section {} left in original raw form, without re-building"
+                          .format(self.vi.src_fname, self.ident, section_num))
             return
 
         exp_whole_len = self.expectedRSRCSize(section_num)
@@ -1164,8 +1165,8 @@ class CompleteBlock(Block):
                 import sys
                 import traceback
                 traceback.print_exc(file=sys.stdout)
-            eprint("{:s}: Warning: Block {} section {} XML export exception: {}."
-                   .format(self.vi.src_fname, self.ident, section_num, str(e)))
+            LV.eprint("{:s}: Warning: Block {} section {} XML export exception: {}."
+                      .format(self.vi.src_fname, self.ident, section_num, str(e)))
             Block.exportXMLSection(self, section_elem, section_num, section, fname_base)
             return
 
@@ -1198,7 +1199,7 @@ class VarCodingBlock(Block):
     def setDefaultEncoding(self, section_num):
         section = self.sections[section_num]
         ver = self.vi.getFileVersion()
-        if isGreaterOrEqVersion(ver, 6,0,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 6,0,0):  # noqa: E231
             section.block_coding = BLOCK_CODING.ZLIB
         else:
             section.block_coding = BLOCK_CODING.NONE
@@ -1335,7 +1336,7 @@ class FPTD(CompleteBlock):
         The block contains single TD index for LV 8.6.0, it does not for LV6.0.1
         """
         ver = self.vi.getFileVersion()
-        return isGreaterOrEqVersion(ver, 7,0,0)  # noqa: E231
+        return LV.isGreaterOrEqVersion(ver, 7,0,0)  # noqa: E231
 
     def parseRSRCSectionData(self, section_num, bldata):
         section = self.sections[section_num]
@@ -1912,12 +1913,12 @@ class STR(SingleStringBlock):
     def isSingleShortString(self):
         from pylabview.LVrsrcontainer import FILE_FMT_TYPE
         ver = self.vi.getFileVersion()
-        return (self.vi.ftype == FILE_FMT_TYPE.LLB) or isSmallerVersion(ver, 8,0,0)  # noqa: E231
+        return (self.vi.ftype == FILE_FMT_TYPE.LLB) or LV.isSmallerVersion(ver, 8,0,0)  # noqa: E231
 
     def isSingleLVVariant(self):
         from pylabview.LVrsrcontainer import FILE_FMT_TYPE
         ver = self.vi.getFileVersion()
-        return (self.vi.ftype == FILE_FMT_TYPE.VI) and isGreaterOrEqVersion(ver, 8,0,0)  # noqa: E231
+        return (self.vi.ftype == FILE_FMT_TYPE.VI) and LV.isGreaterOrEqVersion(ver, 8,0,0)  # noqa: E231
 
     def parseRSRCSectionData(self, section_num, bldata):
         section = self.sections[section_num]
@@ -2162,7 +2163,7 @@ class STRG(StringListBlock):
         """ Properly sets storage mode based on LV version
         """
         ver = self.vi.getFileVersion()
-        if isGreaterOrEqVersion(ver, 4,0,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 4,0,0):  # noqa: E231
             section.count_len = 0
             section.size_len = 4
         else:  # Tested on LV2.5
@@ -2205,7 +2206,7 @@ class LSTsh(StringListBlock):
         if vers is None:
             return 1
         ver = self.vi.getFileVersion()
-        if isSmallerVersion(ver, 11,0,0,0):  # noqa: E231
+        if LV.isSmallerVersion(ver, 11,0,0,0):  # noqa: E231
             return 4
         return 1
 
@@ -2284,8 +2285,8 @@ class LinkObjRefs(CompleteBlock):
             raise AttributeError("List of LinkObjects incorrectly started with {}".format(nextLinkInfo))
         section.ident = bldata.read(4)
         self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "LinkObject[{}].Ident".format(0))
-        if isSmallerVersion(ver, 14,0,0,3):  # noqa: E231
-            section.unk1 = readPStr(bldata, 2, self.po)
+        if LV.isSmallerVersion(ver, 14,0,0,3):  # noqa: E231
+            section.unk1 = LV.readPStr(bldata, 2, self.po)
             self.appendPrintMapEntry(section, bldata.tell(), 1+len(section.unk1), 2, "LinkObject[{}].Unk1".format(0))
             wordlen = int.from_bytes(bldata.read(2), byteorder='big', signed=False)
             section.unk2 = bldata.read(2 * wordlen)
@@ -2328,8 +2329,8 @@ class LinkObjRefs(CompleteBlock):
         data_buf = b''
         data_buf += int(1).to_bytes(2, byteorder='big', signed=False)  # nextLinkInfo
         data_buf += section.ident
-        if isSmallerVersion(ver, 14,0,0,3):  # noqa: E231
-            data_buf += preparePStr(section.unk1, 2, self.po)
+        if LV.isSmallerVersion(ver, 14,0,0,3):  # noqa: E231
+            data_buf += LV.preparePStr(section.unk1, 2, self.po)
             data_buf += int(len(section.unk2)/2).to_bytes(2, byteorder='big', signed=False)
             data_buf += section.unk2
         data_buf += len(section.content).to_bytes(4, byteorder='big', signed=False)
@@ -2344,7 +2345,7 @@ class LinkObjRefs(CompleteBlock):
         ver = self.vi.getFileVersion()
         exp_whole_len = 0
         exp_whole_len += 2 + 4
-        if isSmallerVersion(ver, 14,0,0,3):  # noqa: E231
+        if LV.isSmallerVersion(ver, 14,0,0,3):  # noqa: E231
             str_len = 1 + len(section.unk1)
             uneven_len = str_len % 2
             if uneven_len > 0:
@@ -2362,7 +2363,7 @@ class LinkObjRefs(CompleteBlock):
         return exp_whole_len
 
     def initWithXMLList(self, section, list_elem):
-        section.ident = getRsrcTypeFromPrettyStr(list_elem.tag)
+        section.ident = LV.getRsrcTypeFromPrettyStr(list_elem.tag)
         unk1 = list_elem.get("Unk1")
         if unk1 is not None:
             section.unk1 = unk1.encode(self.vi.textEncoding)
@@ -2371,7 +2372,7 @@ class LinkObjRefs(CompleteBlock):
             section.unk2 = bytes.fromhex(unk2)
         blockref = (self.ident, section.start.section_idx,)
         for subelem in list_elem:
-            lnkobj_ident = getRsrcTypeFromPrettyStr(subelem.tag)
+            lnkobj_ident = LV.getRsrcTypeFromPrettyStr(subelem.tag)
             client = LVlinkinfo.newLinkObject(self.vi, blockref, section.ident, lnkobj_ident, self.po)
             section.content.append(client)
             client.initWithXML(subelem)
@@ -2403,7 +2404,7 @@ class LinkObjRefs(CompleteBlock):
         pass
 
     def exportXMLSectionData(self, section_elem, section_num, section, fname_base):
-        pretty_ident = getPrettyStrFromRsrcType(section.ident)
+        pretty_ident = LV.getPrettyStrFromRsrcType(section.ident)
         list_elem = ET.SubElement(section_elem, pretty_ident)
         if len(section.unk1) > 0 or len(section.unk2) > 0:
             list_elem.set("Unk1", section.unk1.decode(self.vi.textEncoding))
@@ -2490,17 +2491,17 @@ class DFDS(CompleteBlock):
         section = self.sections[section_num]
         ver = self.vi.getFileVersion()
         # Verified uncompressed in LV7.1.0, ZLIB compressed in LV8.6
-        if isGreaterOrEqVersion(ver, 8,0,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 8,0,0):  # noqa: E231
             section.block_coding = BLOCK_CODING.ZLIB
         else:
             section.block_coding = BLOCK_CODING.NONE
 
     def isSpecialDSTMCluster(self, tmEntry):
         return (tmEntry.flags & (
-            TM_FLAGS.TMFBit4 |
-            TM_FLAGS.TMFBit5 |
-            TM_FLAGS.TMFBit6 |
-            TM_FLAGS.TMFBit2)) != 0
+            LVdatatype.TM_FLAGS.TMFBit4 |
+            LVdatatype.TM_FLAGS.TMFBit5 |
+            LVdatatype.TM_FLAGS.TMFBit6 |
+            LVdatatype.TM_FLAGS.TMFBit2)) != 0
 
     def getTypeMapWithDefltData(self):
         TM = self.vi.get_one_of('TM80', 'DSTM')
@@ -2508,17 +2509,17 @@ class DFDS(CompleteBlock):
 
         if TM is None:
             raise RuntimeError("No type map block to put default data into types")
-        elif isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
+        elif LV.isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
             TypeMap = TM.getTypeMap()
             for tmEntry in TypeMap:
-                if (tmEntry.flags & TM_FLAGS.TMFBit3) != 0 or \
-                   (tmEntry.flags & TM_FLAGS.TMFBit11) != 0 or \
-                   (tmEntry.flags & TM_FLAGS.TMFBit10) != 0:
+                if (tmEntry.flags & LVdatatype.TM_FLAGS.TMFBit3) != 0 or \
+                   (tmEntry.flags & LVdatatype.TM_FLAGS.TMFBit11) != 0 or \
+                   (tmEntry.flags & LVdatatype.TM_FLAGS.TMFBit10) != 0:
                     continue
-                if (tmEntry.flags & TM_FLAGS.TMFBit13) != 0 or \
-                   (tmEntry.flags & TM_FLAGS.TMFBit0) != 0:
+                if (tmEntry.flags & LVdatatype.TM_FLAGS.TMFBit13) != 0 or \
+                   (tmEntry.flags & LVdatatype.TM_FLAGS.TMFBit0) != 0:
                     yield tmEntry, 0
-                elif tmEntry.td.fullType() == TD_FULL_TYPE.Cluster and self.isSpecialDSTMCluster(tmEntry):
+                elif tmEntry.td.fullType() == LVdatatype.TD_FULL_TYPE.Cluster and self.isSpecialDSTMCluster(tmEntry):
                     # This is Special DSTM Cluster
                     yield tmEntry, 1
                 else:
@@ -2531,7 +2532,7 @@ class DFDS(CompleteBlock):
         ver = self.vi.getFileVersion()
 
         section.content = []
-        if isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
             blockref = (self.ident, section.start.section_idx,)
             for tmEntry, defDataType in self.getTypeMapWithDefltData():
                 df = None
@@ -2543,7 +2544,7 @@ class DFDS(CompleteBlock):
                         df.initWithRSRC(bldata)
                     except Exception as e:
                         tdType = tmEntry.td.fullType()
-                        raise RuntimeError("Data type {}: {}".format(enumOrIntToName(tdType), str(e)))
+                        raise RuntimeError("Data type {}: {}".format(LV.enumOrIntToName(tdType), str(e)))
                     pass
                 elif defDataType == 1:
                     try:
@@ -2553,7 +2554,7 @@ class DFDS(CompleteBlock):
                         df.initWithRSRC(bldata)
                     except Exception as e:
                         tdType = tmEntry.td.fullType()
-                        raise RuntimeError("Special DSTM {}: {}".format(enumOrIntToName(tdType), str(e)))
+                        raise RuntimeError("Special DSTM {}: {}".format(LV.enumOrIntToName(tdType), str(e)))
                     pass
         else:
             raise NotImplementedError("No support for the LV7.1 default data format")
@@ -2969,7 +2970,7 @@ class FTAB(CompleteBlock):
             if nameOffs == 0:
                 continue
             bldata.seek(nameOffs)
-            fnEntry.name = readPStr(bldata, 1, self.po)
+            fnEntry.name = LV.readPStr(bldata, 1, self.po)
         # At the end of this function, we should place file pointer at end of the data.
         # Since font names seem to always be in order, this should be achieved already.
         pass
@@ -2997,7 +2998,7 @@ class FTAB(CompleteBlock):
                 nameOffsList.append(0)
             else:
                 nameOffsList.append(nameOffsStart+len(namesData))
-                namesData += preparePStr(fnEntry.name, 1, self.po)
+                namesData += LV.preparePStr(fnEntry.name, 1, self.po)
 
         for i, fnEntry in enumerate(section.content):
             nameOffs = nameOffsList[i]
@@ -3221,13 +3222,13 @@ class DTHP(CompleteBlock):
         section.tdCount = 0
         section.content = []
 
-        if isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
-            section.tdCount = readVariableSizeFieldU2p2(bldata)
+        if LV.isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
+            section.tdCount = LV.readVariableSizeFieldU2p2(bldata)
             # If there is no count provided, then there is no shift
             # LV14 writes it like this; though it doesn't support this while reading
             # it reads the non existing value anyway, which really reads padding
             if section.tdCount > 0:
-                section.indexShift = readVariableSizeFieldU2p2(bldata)
+                section.indexShift = LV.readVariableSizeFieldU2p2(bldata)
         else:
             # TODO make support for the 7.1 format
             raise NotImplementedError("Parsing the block from LV7.1 and older is not implemented")
@@ -3238,10 +3239,10 @@ class DTHP(CompleteBlock):
         ver = self.vi.getFileVersion()
 
         data_buf = b''
-        if isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
-            data_buf += prepareVariableSizeFieldU2p2(section.tdCount)
+        if LV.isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
+            data_buf += LV.prepareVariableSizeFieldU2p2(section.tdCount)
             if section.tdCount > 0:
-                data_buf += prepareVariableSizeFieldU2p2(section.indexShift)
+                data_buf += LV.prepareVariableSizeFieldU2p2(section.indexShift)
         else:
             # TODO make support for the 7.1 format
             raise NotImplementedError("Preparing binary data for LV7.1 and older is not implemented")
@@ -3251,7 +3252,7 @@ class DTHP(CompleteBlock):
         section = self.sections[section_num]
         ver = self.vi.getFileVersion()
 
-        if isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
             exp_whole_len = 0
             exp_whole_len += 2
             if section.tdCount > 0:
@@ -3275,7 +3276,7 @@ class DTHP(CompleteBlock):
     def exportXMLSectionData(self, section_elem, section_num, section, fname_base):
         ver = self.vi.getFileVersion()
 
-        if isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 8,0,0,1):  # noqa: E231
             # This is only for a comment, allowed to return None
             VCTP = self.vi.get('VCTP')
 
@@ -3286,7 +3287,7 @@ class DTHP(CompleteBlock):
                     td = VCTP.getTopType(tdIndex)
                 if td is not None:
                     comment_elem = ET.Comment(" Heap TypeID {:2d} = Consolidated TypeID {:2d}: {} "
-                                              .format(i+1, tdIndex, enumOrIntToName(td.fullType())))
+                                              .format(i+1, tdIndex, LV.enumOrIntToName(td.fullType())))
                 else:
                     comment_elem = ET.Comment(" Heap TypeID {:2d} = Consolidated TypeID {:2d} "
                                               .format(i+1, tdIndex))
@@ -3328,7 +3329,7 @@ class DSTM(CompleteBlock):
         section = self.sections[section_num]
         ver = self.vi.getFileVersion()
         # Verified uncompressed in LV7.1.0, compressed in LV8.6
-        if isGreaterOrEqVersion(ver, 8,0,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 8,0,0):  # noqa: E231
             section.block_coding = BLOCK_CODING.ZLIB
         else:
             section.block_coding = BLOCK_CODING.NONE
@@ -3364,7 +3365,7 @@ class TM80(CompleteBlock):
     def setDefaultEncoding(self, section_num):
         section = self.sections[section_num]
         ver = self.vi.getFileVersion()
-        if isGreaterOrEqVersion(ver, 10,0,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 10,0,0):  # noqa: E231
             section.block_coding = BLOCK_CODING.ZLIB
         else:
             section.block_coding = BLOCK_CODING.NONE
@@ -3373,11 +3374,11 @@ class TM80(CompleteBlock):
         section = self.sections[section_num]
 
         section.content = []
-        count = readVariableSizeFieldU2p2(bldata)
+        count = LV.readVariableSizeFieldU2p2(bldata)
         if count > 0:
-            section.indexShift = readVariableSizeFieldU2p2(bldata)
+            section.indexShift = LV.readVariableSizeFieldU2p2(bldata)
         for i in range(count):
-            val = readVariableSizeFieldU2p2(bldata)
+            val = LV.readVariableSizeFieldU2p2(bldata)
             section.content.append(val)
         pass
 
@@ -3385,10 +3386,10 @@ class TM80(CompleteBlock):
         section = self.sections[section_num]
 
         data_buf = b''
-        data_buf += prepareVariableSizeFieldU2p2(len(section.content))
-        data_buf += prepareVariableSizeFieldU2p2(section.indexShift)
+        data_buf += LV.prepareVariableSizeFieldU2p2(len(section.content))
+        data_buf += LV.prepareVariableSizeFieldU2p2(section.indexShift)
         for val in section.content:
-            data_buf += prepareVariableSizeFieldU2p2(val)
+            data_buf += LV.prepareVariableSizeFieldU2p2(val)
         return data_buf
 
     def expectedRSRCSize(self, section_num):
@@ -3409,7 +3410,7 @@ class TM80(CompleteBlock):
             if (subelem.tag == "NameObject"):
                 pass  # Items parsed somewhere else
             elif (subelem.tag == "Client"):
-                val = importXMLBitfields(TM_FLAGS, subelem)
+                val = LV.importXMLBitfields(LVdatatype.TM_FLAGS, subelem)
                 section.content.append(val)
             else:
                 raise AttributeError("Section contains unexpected tag")
@@ -3428,7 +3429,7 @@ class TM80(CompleteBlock):
                 td = VCTP.getTopType(tdIndex)
             if td is not None:
                 comment_elem = ET.Comment(" TypeID {:d}: {} "
-                                          .format(tdIndex, enumOrIntToName(td.fullType())))
+                                          .format(tdIndex, LV.enumOrIntToName(td.fullType())))
             else:
                 comment_elem = ET.Comment(" TypeID {:d} "
                                           .format(tdIndex))
@@ -3436,7 +3437,7 @@ class TM80(CompleteBlock):
 
             subelem = ET.SubElement(section_elem, "Client")
 
-            exportXMLBitfields(TM_FLAGS, subelem, val)
+            LV.exportXMLBitfields(LVdatatype.TM_FLAGS, subelem, val)
 
         if len(section.content) == 0:
             comment_elem = ET.Comment("List of types is empty")
@@ -3459,8 +3460,8 @@ class TM80(CompleteBlock):
             tmEntry.flags = val
             tmEntry.td = VCTP.getTopType(tmEntry.index)
             if tmEntry.td is None:
-                eprint("{:s}: Warning: Block {} section {} references VCTP type {}+{} which does not exist."
-                       .format(self.vi.src_fname, self.ident, section_num, section.indexShift, i))
+                LV.eprint("{:s}: Warning: Block {} section {} references VCTP type {}+{} which does not exist."
+                          .format(self.vi.src_fname, self.ident, section_num, section.indexShift, i))
 
         return tmEntry
 
@@ -3499,8 +3500,8 @@ class TM80(CompleteBlock):
             tmEntry.flags = val
             tmEntry.td = VCTP.getTopType(tmEntry.index)
             if tmEntry.td is None:
-                eprint("{:s}: Warning: Block {} section {} references VCTP type {}+{} which does not exist."
-                       .format(self.vi.src_fname, self.ident, section_num, section.indexShift, i))
+                LV.eprint("{:s}: Warning: Block {} section {} references VCTP type {}+{} which does not exist."
+                          .format(self.vi.src_fname, self.ident, section_num, section.indexShift, i))
             else:
                 typeMap.append(tmEntry)
 
@@ -3531,7 +3532,7 @@ class LVSR(CompleteBlock):
     """
     def createSection(self):
         section = super().createSection()
-        section.version = decodeVersion(0x0)
+        section.version = LV.decodeVersion(0x0)
         section.execFlags = 0
         section.protected = False
         section.viFlags2 = 0
@@ -3572,14 +3573,14 @@ class LVSR(CompleteBlock):
 
         # Size of the data increses with further versions
         # Data before byte 68 does not move - so it's always safe to read
-        data = LVSRData(self.po)
+        data = LVinstrument.LVSRData(self.po)
         dataLen = bldata.readinto(data)
-        if dataLen not in [68, 96, 120, 136, 137, sizeof(LVSRData)]:
+        if dataLen not in [68, 96, 120, 136, 137, sizeof(LVinstrument.LVSRData)]:
             raise EOFError("Data block length {} too small for parsing {} data".format(dataLen, self.ident))
 
-        section.version = decodeVersion(data.version)
-        section.protected = ((data.execFlags & VI_EXEC_FLAGS.LibProtected.value) != 0)
-        section.execFlags = data.execFlags & (~VI_EXEC_FLAGS.LibProtected.value)
+        section.version = LV.decodeVersion(data.version)
+        section.protected = ((data.execFlags & LVinstrument.VI_EXEC_FLAGS.LibProtected.value) != 0)
+        section.execFlags = data.execFlags & (~LVinstrument.VI_EXEC_FLAGS.LibProtected.value)
         section.viFlags2 = int(data.viFlags2)
         section.field0C = int(data.field0C)
         section.flags10 = int(data.flags10)
@@ -3598,22 +3599,22 @@ class LVSR(CompleteBlock):
         # Additional data, exists only in newer versions
         # sizeof(LVSR) per version: 6.0.1->68 7.1.0->96 8.6b7->120 9.0b25->120 9.0->120 10.0b84->120 10.0->136 11.0.1->136
         # 12.0->136 13.0->136 14.0->137
-        if isGreaterOrEqVersion(section.version, 7,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(section.version, 7,0):  # noqa: E231
             section.alignGridFP = int(data.alignGridFP)
             section.alignGridBD = int(data.alignGridBD)
             section.field4C = int(data.field4C)
             section.ctrlIndStyle = int(data.ctrlIndStyle)
             section.field50_md5 = bytes(data.field50_md5)
-        if isGreaterOrEqVersion(section.version, 8,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(section.version, 8,0):  # noqa: E231
             section.libpass_md5 = bytes(data.libpass_md5)
             section.libpass_text = None
             section.field70 = int(data.field70)
             section.field74 = int(data.field74)
-        if isGreaterOrEqVersion(section.version, 10,0, stage='release'):  # noqa: E231
+        if LV.isGreaterOrEqVersion(section.version, 10,0, stage='release'):  # noqa: E231
             section.field78_md5 = bytes(data.field78_md5)
-        if isGreaterOrEqVersion(section.version, 14,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(section.version, 14,0):  # noqa: E231
             section.inlineStg = int(data.inlineStg)
-        if isGreaterOrEqVersion(section.version, 15,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(section.version, 15,0):  # noqa: E231
             section.field8C = int(data.field8C)
         # Any data added in future versions
         section.field90 = bldata.read()
@@ -3621,9 +3622,9 @@ class LVSR(CompleteBlock):
     def prepareRSRCData(self, section_num):
         section = self.sections[section_num]
         data_buf = b''
-        data_buf += int(encodeVersion(section.version)).to_bytes(4, byteorder='big')
-        data_execFlags = (section.execFlags & (~VI_EXEC_FLAGS.LibProtected.value)) | \
-                         (VI_EXEC_FLAGS.LibProtected.value if section.protected else 0)
+        data_buf += int(LV.encodeVersion(section.version)).to_bytes(4, byteorder='big')
+        data_execFlags = (section.execFlags & (~LVinstrument.VI_EXEC_FLAGS.LibProtected.value)) | \
+                         (LVinstrument.VI_EXEC_FLAGS.LibProtected.value if section.protected else 0)
         data_buf += int(data_execFlags).to_bytes(4, byteorder='big')
         data_buf += int(section.viFlags2).to_bytes(4, byteorder='big')
         data_buf += int(section.field0C).to_bytes(4, byteorder='big')
@@ -3640,23 +3641,23 @@ class LVSR(CompleteBlock):
         data_buf += int(section.field2C).to_bytes(4, byteorder='big')
         data_buf += int(section.field30).to_bytes(4, byteorder='big')
         data_buf += section.viSignature
-        if isGreaterOrEqVersion(section.version, 7,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(section.version, 7,0):  # noqa: E231
             data_buf += int(section.alignGridFP).to_bytes(4, byteorder='big')
             data_buf += int(section.alignGridBD).to_bytes(4, byteorder='big')
             data_buf += int(section.field4C).to_bytes(2, byteorder='big')
             data_buf += int(section.ctrlIndStyle).to_bytes(2, byteorder='big')
             data_buf += section.field50_md5
-        if isGreaterOrEqVersion(section.version, 8,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(section.version, 8,0):  # noqa: E231
             if section.libpass_text is not None:
                 pass  # TODO re-compute md5 from pass
             data_buf += section.libpass_md5
             data_buf += int(section.field70).to_bytes(4, byteorder='big')
             data_buf += int(section.field74).to_bytes(4, byteorder='big', signed=True)
-        if isGreaterOrEqVersion(section.version, 10,0, stage='release'):  # noqa: E231
+        if LV.isGreaterOrEqVersion(section.version, 10,0, stage='release'):  # noqa: E231
             data_buf += section.field78_md5
-        if isGreaterOrEqVersion(section.version, 14,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(section.version, 14,0):  # noqa: E231
             data_buf += int(section.inlineStg).to_bytes(1, byteorder='big')
-        if isGreaterOrEqVersion(section.version, 15,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(section.version, 15,0):  # noqa: E231
             data_buf += b'\0' * 3
             data_buf += int(section.field8C).to_bytes(4, byteorder='big')
         data_buf += section.field90
@@ -3667,15 +3668,15 @@ class LVSR(CompleteBlock):
         ver = self.vi.getFileVersion()
         exp_whole_len = 68
 
-        if isGreaterOrEqVersion(section.version, 7,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(section.version, 7,0):  # noqa: E231
             exp_whole_len += 28
-        if isGreaterOrEqVersion(section.version, 8,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(section.version, 8,0):  # noqa: E231
             exp_whole_len += 24
-        if isGreaterOrEqVersion(section.version, 10,0, stage='release'):  # noqa: E231
+        if LV.isGreaterOrEqVersion(section.version, 10,0, stage='release'):  # noqa: E231
             exp_whole_len += 16  # total 136
-        if isGreaterOrEqVersion(section.version, 14,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(section.version, 14,0):  # noqa: E231
             exp_whole_len += 1  # total 137
-        if isGreaterOrEqVersion(section.version, 15,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(section.version, 15,0):  # noqa: E231
             exp_whole_len += 3 + 4
         exp_whole_len += len(section.field90)
         return exp_whole_len
@@ -3697,7 +3698,7 @@ class LVSR(CompleteBlock):
                 ver['build'] = int(subelem.get("Build"), 0)
                 section.version = ver
                 # the call below sets numeric 'stage' from text; we do not care for actual encoding
-                encodeVersion(section.version)
+                LV.encodeVersion(section.version)
             elif (subelem.tag == "Library"):
                 section.protected = int(subelem.get("Protected"), 0)
                 password_text = subelem.get("Password")
@@ -3713,23 +3714,23 @@ class LVSR(CompleteBlock):
                 section.execState = int(subelem.get("State"), 0)
                 section.execPrio = int(subelem.get("Priority"), 0)
                 section.prefExecSyst = int(subelem.get("PrefExecSyst"), 0)
-                section.execFlags = importXMLBitfields(VI_EXEC_FLAGS, subelem)
+                section.execFlags = LV.importXMLBitfields(LVinstrument.VI_EXEC_FLAGS, subelem)
             elif (subelem.tag == "Execution2"):
-                section.viFlags2 = importXMLBitfields(VI_FLAGS2, subelem)
+                section.viFlags2 = LV.importXMLBitfields(LVinstrument.VI_FLAGS2, subelem)
             elif (subelem.tag == "ButtonsHidden"):
-                section.buttonsHidden = importXMLBitfields(VI_BTN_HIDE_FLAGS, subelem)
+                section.buttonsHidden = LV.importXMLBitfields(LVinstrument.VI_BTN_HIDE_FLAGS, subelem)
             elif (subelem.tag == "Instrument"):
-                section.viType = valFromEnumOrIntString(VI_TYPE, subelem.get("Type"))
+                section.viType = LV.valFromEnumOrIntString(LVinstrument.VI_TYPE, subelem.get("Type"))
                 tmphash = subelem.get("Signature")
                 section.viSignature = bytes.fromhex(tmphash)
-                section.instrState = importXMLBitfields(VI_IN_ST_FLAGS, subelem)
+                section.instrState = LV.importXMLBitfields(LVinstrument.VI_IN_ST_FLAGS, subelem)
             elif (subelem.tag == "FrontPanel"):
                 section.ctrlIndStyle = int(subelem.get("CtrlIndStyle"), 0)
-                section.frontpFlags = importXMLBitfields(VI_FP_FLAGS, subelem)
+                section.frontpFlags = LV.importXMLBitfields(LVinstrument.VI_FP_FLAGS, subelem)
             elif (subelem.tag == "Flags0C"):
-                section.field0C = importXMLBitfields(VI_FLAGS0C, subelem)
+                section.field0C = LV.importXMLBitfields(LVinstrument.VI_FLAGS0C, subelem)
             elif (subelem.tag == "Flags12"):
-                section.field12 = importXMLBitfields(VI_FLAGS12, subelem)
+                section.field12 = LV.importXMLBitfields(LVinstrument.VI_FLAGS12, subelem)
             elif (subelem.tag == "Unknown"):
                 section.flags10 = int(subelem.get("Flags10"), 0)
                 section.field28 = int(subelem.get("Field28"), 0)
@@ -3782,29 +3783,29 @@ class LVSR(CompleteBlock):
         subelem.set("State", "{:d}".format(section.execState))
         subelem.set("Priority", "{:d}".format(section.execPrio))
         subelem.set("PrefExecSyst", "{:d}".format(section.prefExecSyst))
-        exportXMLBitfields(VI_EXEC_FLAGS, subelem, section.execFlags,
-                           skip_mask=VI_EXEC_FLAGS.LibProtected.value)
+        LV.exportXMLBitfields(LVinstrument.VI_EXEC_FLAGS, subelem, section.execFlags,
+                              skip_mask=LVinstrument.VI_EXEC_FLAGS.LibProtected.value)
 
         subelem = ET.SubElement(section_elem, "Execution2")
-        exportXMLBitfields(VI_FLAGS2, subelem, section.viFlags2)
+        LV.exportXMLBitfields(LVinstrument.VI_FLAGS2, subelem, section.viFlags2)
 
         subelem = ET.SubElement(section_elem, "ButtonsHidden")
-        exportXMLBitfields(VI_BTN_HIDE_FLAGS, subelem, section.buttonsHidden)
+        LV.exportXMLBitfields(LVinstrument.VI_BTN_HIDE_FLAGS, subelem, section.buttonsHidden)
 
         subelem = ET.SubElement(section_elem, "Instrument")
-        subelem.set("Type", "{:s}".format(stringFromValEnumOrInt(VI_TYPE, section.viType)))
+        subelem.set("Type", "{:s}".format(LV.stringFromValEnumOrInt(LVinstrument.VI_TYPE, section.viType)))
         subelem.set("Signature", section.viSignature.hex())
-        exportXMLBitfields(VI_IN_ST_FLAGS, subelem, section.instrState)
+        LV.exportXMLBitfields(LVinstrument.VI_IN_ST_FLAGS, subelem, section.instrState)
 
         subelem = ET.SubElement(section_elem, "FrontPanel")
         subelem.set("CtrlIndStyle", "{:d}".format(section.ctrlIndStyle))
-        exportXMLBitfields(VI_FP_FLAGS, subelem, section.frontpFlags)
+        LV.exportXMLBitfields(LVinstrument.VI_FP_FLAGS, subelem, section.frontpFlags)
 
         subelem = ET.SubElement(section_elem, "Flags0C")
-        exportXMLBitfields(VI_FLAGS0C, subelem, section.field0C)
+        LV.exportXMLBitfields(LVinstrument.VI_FLAGS0C, subelem, section.field0C)
 
         subelem = ET.SubElement(section_elem, "Flags12")
-        exportXMLBitfields(VI_FLAGS12, subelem, section.field12)
+        LV.exportXMLBitfields(LVinstrument.VI_FLAGS12, subelem, section.field12)
 
         subelem = ET.SubElement(section_elem, "Unknown")
 
@@ -3858,25 +3859,25 @@ class vers(Block):
     def parseRSRCData(self, section_num, bldata):
         section = self.sections[section_num]
 
-        section.version = decodeVersion(int.from_bytes(bldata.read(4), byteorder='big', signed=False))
+        section.version = LV.decodeVersion(int.from_bytes(bldata.read(4), byteorder='big', signed=False))
         section.language = int.from_bytes(bldata.read(2), byteorder='big', signed=False)
         version_info_len = int.from_bytes(bldata.read(1), byteorder='big', signed=False)
         section.version_info = bldata.read(version_info_len)
         comment_len = int.from_bytes(bldata.read(1), byteorder='big', signed=False)
         section.comment = bldata.read(comment_len)
-        if isGreaterOrEqVersion(self.version, 8,6,0) and comment_len != 0:  # noqa: E231
-            eprint("Warning: Block {} section {} comment length is {} instead of {}"
-                   .format(self.ident, section_num, comment_len, 0))
+        if LV.isGreaterOrEqVersion(self.version, 8,6,0) and comment_len != 0:  # noqa: E231
+            LV.eprint("Warning: Block {} section {} comment length is {} instead of {}"
+                      .format(self.ident, section_num, comment_len, 0))
 
     def updateSectionData(self, section_num=None):
         if section_num is None:
             section_num = self.active_section_num
         section = self.sections[section_num]
 
-        data_buf = int(encodeVersion(section.version)).to_bytes(4, byteorder='big')
+        data_buf = int(LV.encodeVersion(section.version)).to_bytes(4, byteorder='big')
         data_buf += section.language.to_bytes(2, byteorder='big')
-        data_buf += preparePStr(section.version_info, 1, self.po)
-        data_buf += preparePStr(section.comment, 1, self.po)
+        data_buf += LV.preparePStr(section.version_info, 1, self.po)
+        data_buf += LV.preparePStr(section.comment, 1, self.po)
 
         if len(data_buf) != 4 + 2 + 1+len(section.version_info) + 1+len(section.comment):
             raise RuntimeError("Block {} section {} generated binary data of invalid size"
@@ -3915,7 +3916,7 @@ class vers(Block):
                     section.comment = subelem.get("Comment").encode(self.vi.textEncoding)
                     section.version = ver
                     # the call below sets numeric 'stage' from text; we do not care for actual encoding
-                    encodeVersion(section.version)
+                    LV.encodeVersion(section.version)
                 else:
                     raise AttributeError("Section contains something else than 'Version'")
         else:
@@ -4085,11 +4086,11 @@ class RawImageBlock(ImageBlock):
         image = Image.new("P", (padded_width, height))
         img_palette = [0] * (3*256)
         if bpp == 8:
-            lv_color_palette = LABVIEW_COLOR_PALETTE_256
+            lv_color_palette = LV.LABVIEW_COLOR_PALETTE_256
         elif bpp == 4:
-            lv_color_palette = LABVIEW_COLOR_PALETTE_16
+            lv_color_palette = LV.LABVIEW_COLOR_PALETTE_16
         else:
-            lv_color_palette = LABVIEW_COLOR_PALETTE_2
+            lv_color_palette = LV.LABVIEW_COLOR_PALETTE_2
         for i, rgb in enumerate(lv_color_palette):
             img_palette[3*i+0] = (rgb >> 16) & 0xFF
             img_palette[3*i+1] = (rgb >>  8) & 0xFF  # noqa: E222
@@ -4379,7 +4380,7 @@ class BDPW(Block):
         Tested not to be there in LV7.1, is there in LV8.6b7
         """
         ver = self.vi.getFileVersion()
-        return isGreaterOrEqVersion(ver, 8,0,0)  # noqa: E231
+        return LV.isGreaterOrEqVersion(ver, 8,0,0)  # noqa: E231
 
     def parseRSRCData(self, section_num, bldata):
         section = self.sections[section_num]
@@ -4408,8 +4409,8 @@ class BDPW(Block):
 
         exp_whole_len = self.expectedRSRCSize(section_num)
         if (len(data_buf) != exp_whole_len):
-            eprint("{:s}: Warning: Block {} section {} generated binary data of size {:d}, expected {:d}"
-                   .format(self.vi.src_fname, self.ident, section_num, len(data_buf), exp_whole_len))
+            LV.eprint("{:s}: Warning: Block {} section {} generated binary data of size {:d}, expected {:d}"
+                      .format(self.vi.src_fname, self.ident, section_num, len(data_buf), exp_whole_len))
 
         self.setData(data_buf, section_num=section_num)
 
@@ -4425,8 +4426,8 @@ class BDPW(Block):
             self.recalculateHash1(section_num=snum, store=False)  # this is needed to find salt
             self.recognizePassword(section_num=snum)
         except Exception as e:
-            eprint("{:s}: Warning: Block {} section {} could not be fully parametrized: {}"
-                   .format(self.vi.src_fname, self.ident, snum, str(e)))
+            LV.eprint("{:s}: Warning: Block {} section {} could not be fully parametrized: {}"
+                      .format(self.vi.src_fname, self.ident, snum, str(e)))
             pass
 
         subelem = ET.SubElement(section_elem, "Password")
@@ -4510,13 +4511,13 @@ class BDPW(Block):
         salt = b''
         salt_source = "None"
         ver = self.vi.getFileVersion()
-        if not isGreaterOrEqVersion(ver, 1,0):  # noqa: E231
+        if not LV.isGreaterOrEqVersion(ver, 1,0):  # noqa: E231
             if (self.po.verbose > 0):
-                eprint("{:s}: Warning: No version block found; assuming oldest format, with empty password salt"
-                       .format(self.vi.src_fname))
+                LV.eprint("{:s}: Warning: No version block found; assuming oldest format, with empty password salt"
+                          .format(self.vi.src_fname))
             section.salt = salt
             return salt
-        if isGreaterOrEqVersion(ver, 12,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 12,0):  # noqa: E231
             # Figure out the salt
             salt_td_flat_idx = None
             VCTP = self.vi.get_or_raise('VCTP')
@@ -4535,7 +4536,7 @@ class BDPW(Block):
                         salt_td_flat_idx = iface_obj.index
                         salt_source = "CPC2"
             if salt_td_flat_idx is None:
-                interfaceEnumerate = self.vi.consolidatedTDEnumerate(fullType=TD_FULL_TYPE.Function)
+                interfaceEnumerate = self.vi.consolidatedTDEnumerate(fullType=LVdatatype.TD_FULL_TYPE.Function)
                 # Check if one of the interfaces is the source of salt; usually it's the last interface, so check in reverse
                 for i, iface_idx, iface_obj in reversed(interfaceEnumerate):
                     term_typedescs = VCTP.getClientTypeDescsByType(iface_obj)
@@ -4737,7 +4738,7 @@ class LIBN(CompleteBlock):
             raise RuntimeError("String list consists of {:d} tags, limit is {:d}"
                                .format(count, self.po.typedesc_list_limit))
         for i in range(count):
-            name = readPStr(bldata, 1, self.po)
+            name = LV.readPStr(bldata, 1, self.po)
             section.content.append(name)
         pass
 
@@ -4747,7 +4748,7 @@ class LIBN(CompleteBlock):
         data_buf = b''
         data_buf += int(len(section.content)).to_bytes(4, byteorder='big', signed=False)
         for name in section.content:
-            data_buf += preparePStr(name, 1, self.po)
+            data_buf += LV.preparePStr(name, 1, self.po)
         return data_buf
 
     def expectedRSRCSize(self, section_num):
@@ -4874,7 +4875,7 @@ class PRT(CompleteBlock):
         section.field90 = b''
         # The size is 128 bytes for LV7.0 and older, and LV 14.0 and newer; but for some
         # versions between, there are additional 24 bytes in this block, zero-filled
-        if isGreaterOrEqVersion(ver, 10,0,0,4):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 10,0,0,4):  # noqa: E231
             section.field90 = bldata.read(24)
 
     def prepareRSRCData(self, section_num):
@@ -4914,7 +4915,7 @@ class PRT(CompleteBlock):
         data_buf += int(section.field84).to_bytes(4, byteorder='big', signed=False)
         data_buf += int(section.field88).to_bytes(4, byteorder='big', signed=False)
         data_buf += int(section.field8C).to_bytes(4, byteorder='big', signed=False)
-        if isGreaterOrEqVersion(ver, 10,0,0,4):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 10,0,0,4):  # noqa: E231
             data_buf += section.field90
         return data_buf
 
@@ -5208,8 +5209,8 @@ class HeapVerb(CompleteBlock):
             tot_len += entry_len
 
         if parentNode is not None:
-            eprint("{}: Warning: In block {}, heap did not closed all tags"
-                   .format(self.vi.src_fname, self.ident))
+            LV.eprint("{}: Warning: In block {}, heap did not closed all tags"
+                      .format(self.vi.src_fname, self.ident))
         pass
 
     def prepareRSRCData(self, section_num):
@@ -5280,8 +5281,8 @@ class HeapVerb(CompleteBlock):
             elif scopeInfo == LVheap.NODE_SCOPE.TagClose:
                 elem = parent_elems.pop()
                 if elem.tag != tagName:
-                    eprint("{}: Warning: In block {}, closing tag {} instead of {}"
-                           .format(self.vi.src_fname, self.ident, tagName, elem.tag))
+                    LV.eprint("{}: Warning: In block {}, closing tag {} instead of {}"
+                              .format(self.vi.src_fname, self.ident, tagName, elem.tag))
             else:
                 # Having two root items would crash here. And that's good, we can't have two roots.
                 elem = ET.SubElement(parent_elems[-1], tagName)
@@ -5292,8 +5293,8 @@ class HeapVerb(CompleteBlock):
                 parent_elems.append(elem)
 
         if len(parent_elems) > 0:
-            eprint("{}: Warning: In block {}, heap structure is not a valid XML tree"
-                   .format(self.vi.src_fname, self.ident))
+            LV.eprint("{}: Warning: In block {}, heap structure is not a valid XML tree"
+                      .format(self.vi.src_fname, self.ident))
         pass
 
     def initWithXMLLate(self):
@@ -5501,7 +5502,7 @@ class GCPR(CompleteBlock):
             client.prop2 = int.from_bytes(bldata.read(4), byteorder='big', signed=False)
             client.prop3 = int.from_bytes(bldata.read(4), byteorder='big', signed=False)
             client.prop4 = int.from_bytes(bldata.read(4), byteorder='big', signed=False)
-            client.prop5 = readLStr(bldata, 1, self.po)
+            client.prop5 = LV.readLStr(bldata, 1, self.po)
             section.content.append(client)
         pass
 
@@ -5523,7 +5524,7 @@ class GCPR(CompleteBlock):
             data_buf += int(client.prop2).to_bytes(4, byteorder='big', signed=False)
             data_buf += int(client.prop3).to_bytes(4, byteorder='big', signed=False)
             data_buf += int(client.prop4).to_bytes(4, byteorder='big', signed=False)
-            data_buf += prepareLStr(client.prop5, 1, self.po)
+            data_buf += LV.prepareLStr(client.prop5, 1, self.po)
 
         return data_buf
 
@@ -5655,7 +5656,7 @@ class UCRF(VarCodingBlock):
                     snum_str = 'm' + str(-snum)
                 fname_base = "{:s}_{:s}".format(fname_base, snum_str)
         else:
-            pretty_ident = getPrettyStrFromRsrcType(self.ident)
+            pretty_ident = LV.getPrettyStrFromRsrcType(self.ident)
             if len(self.sections) == 1:
                 fname_base = "{:s}_{:s}".format(fname_base, pretty_ident)
             else:
@@ -5735,24 +5736,24 @@ class TypeDescListBase(CompleteBlock):
         section = self.sections[section_num]
 
         bldata.seek(pos)
-        obj_type, obj_flags, obj_len = TDObject.parseRSRCDataHeader(bldata)
+        obj_type, obj_flags, obj_len = LVdatatype.TDObject.parseRSRCDataHeader(bldata)
         if (self.po.verbose > 2):
             print("{:s}: Block {} TypeDesc {:d}, at 0x{:04x}, type 0x{:02x} flags 0x{:02x} len {:d}"
                   .format(self.vi.src_fname, self.ident, len(section.content), pos, obj_type, obj_flags, obj_len))
         blockref = (self.ident, section.start.section_idx,)
         # This block is typically compressed within RSRC file; add entries to RSRC map only if there is no compression
         if self.po.print_map is not None:
-            if obj_type not in set(item.value for item in TD_FULL_TYPE):
+            if obj_type not in set(item.value for item in LVdatatype.TD_FULL_TYPE):
                 obj_type_str = "Type_{}".format(obj_type)
             else:
-                obj_type_str = TD_FULL_TYPE(obj_type).name
+                obj_type_str = LVdatatype.TD_FULL_TYPE(obj_type).name
             self.appendPrintMapEntry(section, bldata.tell(), bldata.tell()-pos, 1,
                                      "TypeDesc[{}].{}.Header".format(td_idx, obj_type_str))
         if obj_len < 4:
-            eprint("{:s}: Warning: TypeDesc {:d} type 0x{:02x} data size {:d} too small to be valid"
-                   .format(self.vi.src_fname, len(section.content), obj_type, obj_len))
-            obj_type = TD_FULL_TYPE.Void
-        obj = newTDObject(self.vi, blockref, len(section.content), obj_flags, obj_type, self.po)
+            LV.eprint("{:s}: Warning: TypeDesc {:d} type 0x{:02x} data size {:d} too small to be valid"
+                      .format(self.vi.src_fname, len(section.content), obj_type, obj_len))
+            obj_type = LVdatatype.TD_FULL_TYPE.Void
+        obj = LVdatatype.newTDObject(self.vi, blockref, len(section.content), obj_flags, obj_type, self.po)
 
         clientTD = SimpleNamespace()
         clientTD.index = -1  # Nested clients have index -1
@@ -5782,21 +5783,21 @@ class TypeDescListBase(CompleteBlock):
     def parseRSRCTopTypesList(self, section_num, section, bldata):
         section.topLevel = []
         obj_pos = bldata.tell()
-        count = readVariableSizeFieldU2p2(bldata)
+        count = LV.readVariableSizeFieldU2p2(bldata)
         self.appendPrintMapEntry(section, bldata.tell(), bldata.tell()-obj_pos, 1, "TopTypesListCount")
         for i in range(count):
             obj_pos = bldata.tell()
-            val = readVariableSizeFieldU2p2(bldata)
+            val = LV.readVariableSizeFieldU2p2(bldata)
             self.appendPrintMapEntry(section, bldata.tell(), bldata.tell()-obj_pos, 1, "TypeDesc[{}].Index".format(i))
             section.topLevel.append(val)
         pass
 
     def initWithXMLTypeDesc(self, section, td_elem):
         obj_idx = len(section.content)
-        obj_type = valFromEnumOrIntString(TD_FULL_TYPE, td_elem.get("Type"))
-        obj_flags = importXMLBitfields(TYPEDESC_FLAGS, td_elem)
+        obj_type = LV.valFromEnumOrIntString(LVdatatype.TD_FULL_TYPE, td_elem.get("Type"))
+        obj_flags = LV.importXMLBitfields(LVdatatype.TYPEDESC_FLAGS, td_elem)
         blockref = (self.ident, section.start.section_idx,)
-        obj = newTDObject(self.vi, blockref, obj_idx, obj_flags, obj_type, self.po)
+        obj = LVdatatype.newTDObject(self.vi, blockref, obj_idx, obj_flags, obj_type, self.po)
         clientTD = SimpleNamespace()
         clientTD.index = -1  # Nested clients have index -1
         clientTD.flags = 0  # Only Type Mapped entries have it non-zero
@@ -5864,14 +5865,14 @@ class TypeDescListBase(CompleteBlock):
             section_elem.append(comment_elem)
             subelem = ET.SubElement(section_elem, "TypeDesc")
 
-            subelem.set("Type", "{:s}".format(stringFromValEnumOrInt(TD_FULL_TYPE, clientTD.nested.otype)))
+            subelem.set("Type", "{:s}".format(LV.stringFromValEnumOrInt(LVdatatype.TD_FULL_TYPE, clientTD.nested.otype)))
 
             if not self.po.raw_connectors:
                 clientTD.nested.exportXML(subelem, "{:s}_td{:04d}".format(fname_base, i))
                 clientTD.nested.exportXMLFinish(subelem)
             else:
-                TDObject.exportXML(clientTD.nested, subelem, "{:s}_td{:04d}".format(fname_base, i))
-                TDObject.exportXMLFinish(clientTD.nested, subelem)
+                LVdatatype.TDObject.exportXML(clientTD.nested, subelem, "{:s}_td{:04d}".format(fname_base, i))
+                LVdatatype.TDObject.exportXMLFinish(clientTD.nested, subelem)
         pass
 
     def exportXMLTopTypesList(self, section_elem, section_num, section, fname_base):
@@ -5894,8 +5895,8 @@ class TypeDescListBase(CompleteBlock):
         for i, val in enumerate(section.topLevel):
             if val >= len(section.content):
                 if (self.po.verbose > 1):
-                    eprint("{:s}: Warning: TopLevel index {:d} exceeds flat TD count {:d}"
-                           .format(self.vi.src_fname, i, len(section.content)))
+                    LV.eprint("{:s}: Warning: TopLevel index {:d} exceeds flat TD count {:d}"
+                              .format(self.vi.src_fname, i, len(section.content)))
                 ret = False
         return ret
 
@@ -5960,7 +5961,7 @@ class TypeDescListBase(CompleteBlock):
                     match = False
                     break
                 expectedCType = DCO._fields_[cli_idx][1]
-                expectedType = ctypeToFullTypeEnum(expectedCType)
+                expectedType = LVdatatype.ctypeToFullTypeEnum(expectedCType)
                 if expectedType is not None and td_obj.fullType() != expectedType:
                     match = False
                     break
@@ -6212,7 +6213,7 @@ class VICD(CompleteBlock):
         section = self.sections[section_num]
         ver = self.vi.getFileVersion()
         # verified NONE in 5.1, ZLIB in 8.6
-        if isGreaterOrEqVersion(ver, 8,0,0,3):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 8,0,0,3):  # noqa: E231
             section.block_coding = BLOCK_CODING.ZLIB
         else:
             section.block_coding = BLOCK_CODING.NONE
@@ -6239,7 +6240,7 @@ class VICD(CompleteBlock):
     def parseRSRCSectionHead(self, section, section_num, bldata):
         ver = self.vi.getFileVersion()
 
-        if isGreaterOrEqVersion(ver, 12,0,0,0):  # noqa: E231  # Should be False for LV 11,0,0,4, True for 14,0,0,3
+        if LV.isGreaterOrEqVersion(ver, 12,0,0,0):  # noqa: E231  # Should be False for LV 11,0,0,4, True for 14,0,0,3
             initProcOffset = bldata.read(4)
             self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "Head.initProcOffset")
             section.codeID = bldata.read(4)
@@ -6268,7 +6269,7 @@ class VICD(CompleteBlock):
             self.appendPrintMapEntry(section, bldata.tell(), archDependLen, 1, "Head.codeEndOffset")
             section.signatureName = int.from_bytes(bldata.read(4), byteorder='big', signed=False)
             self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "Head.signatureName")
-        elif isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231  # Lowest version tested with this is LV 6,0,0,2
+        elif LV.isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231  # Lowest version tested with this is LV 6,0,0,2
             initProcOffset = bldata.read(4)
             self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "Head.initProcOffset")
             section.codeID = bldata.read(4)
@@ -6324,7 +6325,7 @@ class VICD(CompleteBlock):
         ver = self.vi.getFileVersion()
         data_buf = b''
 
-        if isGreaterOrEqVersion(ver, 12,0,0,0):  # noqa: E231  # Should be False for LV 11,0,0,4, True for 14,0,0,3
+        if LV.isGreaterOrEqVersion(ver, 12,0,0,0):  # noqa: E231  # Should be False for LV 11,0,0,4, True for 14,0,0,3
             data_buf += int(section.initProcOffset).to_bytes(4, byteorder=archEndianness, signed=False)
             data_buf += section.codeID[:4]
             data_buf += int(section.pTabOffset).to_bytes(4, byteorder=archEndianness, signed=False)
@@ -6336,7 +6337,7 @@ class VICD(CompleteBlock):
             data_buf += int(section.hostCodeEntryVI).to_bytes(4, byteorder=archEndianness, signed=False)
             data_buf += int(section.codeEndOffset).to_bytes(archDependLen, byteorder=archEndianness, signed=False)
             data_buf += int(section.signatureName).to_bytes(4, byteorder='big', signed=False)
-        elif isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231
+        elif LV.isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231
             data_buf += int(section.initProcOffset).to_bytes(4, byteorder=archEndianness, signed=False)
             data_buf += section.codeID[:4]
             data_buf += int(section.pTabOffset).to_bytes(4, byteorder=archEndianness, signed=False)
@@ -6360,7 +6361,7 @@ class VICD(CompleteBlock):
         archDependLen = 8 if self.isX64(section_num) else 4
 
         exp_whole_len = 0
-        if isGreaterOrEqVersion(ver, 12,0,0,0):  # noqa: E231  # Should be False for LV 11,0,0,4, True for 14,0,0,3
+        if LV.isGreaterOrEqVersion(ver, 12,0,0,0):  # noqa: E231  # Should be False for LV 11,0,0,4, True for 14,0,0,3
             exp_whole_len += 4 + 4 + 4 + 4 + 4 + 4 + 4 + 4 + 4 + archDependLen + 4
         else:  # Lowest version tested with this is LV 6,0,0,2
             exp_whole_len += 4 + 4 + 4 + 4 + 4 + 4 + 4 + archDependLen + 4 + 4
@@ -6370,14 +6371,14 @@ class VICD(CompleteBlock):
         ver = self.vi.getFileVersion()
 
         # Oldest versions have no footer
-        if isSmallerVersion(ver, 5,0,0,0):  # noqa: E231
+        if LV.isSmallerVersion(ver, 5,0,0,0):  # noqa: E231
             return
 
         section.endVerifier = bldata.read(4)
         self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "Foot.endVerifier")
         section.endProp1 = int.from_bytes(bldata.read(4), byteorder='big', signed=False)
 
-        if isGreaterOrEqVersion(ver, 7,0,0,0):  # noqa: E231  # Should be False for LV 6,0,0,2, True for 7,1,0,3
+        if LV.isGreaterOrEqVersion(ver, 7,0,0,0):  # noqa: E231  # Should be False for LV 6,0,0,2, True for 7,1,0,3
             # TODO inconsistency - signatureName doesn't have arch-dependant size
             section.endSignatureName = int.from_bytes(bldata.read(archDependLen), byteorder='big', signed=False)
             self.appendPrintMapEntry(section, bldata.tell(), archDependLen, 1, "Foot.endSignatureName")
@@ -6388,7 +6389,7 @@ class VICD(CompleteBlock):
         section.endCodeEndOffset = int.from_bytes(bldata.read(4), byteorder=archEndianness, signed=False)
         self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "Foot.endCodeEndOffset")
 
-        if isGreaterOrEqVersion(ver, 13,0,0,0):  # noqa: E231  # Should be False for 12,0,0,4, True for 14,0,0,3
+        if LV.isGreaterOrEqVersion(ver, 13,0,0,0):  # noqa: E231  # Should be False for 12,0,0,4, True for 14,0,0,3
             # TODO maybe for 64-bit arch it's a missing part of endCodeEndOffset?
             section.endProp5 = int.from_bytes(bldata.read(4), byteorder='big', signed=False)
             self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "Foot.endProp5")
@@ -6399,19 +6400,19 @@ class VICD(CompleteBlock):
         data_buf = b''
 
         # Oldest versions have no footer
-        if isSmallerVersion(ver, 5,0,0,0):  # noqa: E231
+        if LV.isSmallerVersion(ver, 5,0,0,0):  # noqa: E231
             return data_buf
 
         data_buf += section.endVerifier[:4]
         data_buf += int(section.endProp1).to_bytes(4, byteorder='big', signed=False)
 
-        if isGreaterOrEqVersion(ver, 7,0,0,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 7,0,0,0):  # noqa: E231
             data_buf += int(section.endSignatureName).to_bytes(archDependLen, byteorder='big', signed=False)
             data_buf += int(section.endLocalLVRTCodeBlocks).to_bytes(archDependLen, byteorder='big', signed=False)
 
         data_buf += int(section.endCodeEndOffset).to_bytes(4, byteorder=archEndianness, signed=False)
 
-        if isGreaterOrEqVersion(ver, 13,0,0,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 13,0,0,0):  # noqa: E231
             data_buf += int(section.endProp5).to_bytes(4, byteorder='big', signed=False)
         return data_buf
 
@@ -6421,17 +6422,17 @@ class VICD(CompleteBlock):
 
         exp_whole_len = 0
         exp_whole_len += 4 + 4
-        if isGreaterOrEqVersion(ver, 7,0,0,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 7,0,0,0):  # noqa: E231
             exp_whole_len += archDependLen + archDependLen
         exp_whole_len += 4
-        if isGreaterOrEqVersion(ver, 13,0,0,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 13,0,0,0):  # noqa: E231
             exp_whole_len += 4
         return exp_whole_len
 
     def parseRSRCSectionMCLVRTPatches(self, section, section_num, pos, archEndianness, archDependLen, bldata):
         section.patches = []
-        codeTotLen = section.codeEndOffset
-        patchesTotLen = section.codeEndOffset - section.pTabOffset
+        codeTotLen = section.codeEndOffset  # noqa F841  # may not be needed, see TODO below
+        patchesTotLen = section.codeEndOffset - section.pTabOffset  # noqa F841  # may not be needed, see TODO below
         bldata.seek(pos)
         # TODO parse the patches instead of just reading raw data
         raise NotImplementedError("No parsing made for MCLVRTPatches")
@@ -6458,10 +6459,10 @@ class VICD(CompleteBlock):
             self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "Patch[{}].Ident".format(pidx))
 
             badOffset = False
-            if isGreaterOrEqVersion(ver, 14,0,0,0):  # noqa: E231
+            if LV.isGreaterOrEqVersion(ver, 14,0,0,0):  # noqa: E231
                 if patch.offs >= codeTotLen and patch.ident != 0x20000:
                     badOffset = True
-            elif isGreaterOrEqVersion(ver, 6,0,0,0):  # noqa: E231
+            elif LV.isGreaterOrEqVersion(ver, 6,0,0,0):  # noqa: E231
                 # Confirmed for LV6.0 and LV8.6 (though the format inside is different below 8.6)
                 if patch.offs >= codeTotLen and patch.ident != 0xffffffff:
                     badOffset = True
@@ -6473,8 +6474,8 @@ class VICD(CompleteBlock):
             patch.relocs = []
             section.patches.append(patch)
 
-            if (isGreaterOrEqVersion(ver, 10,0,0,0) and (patch.ident == 0x20000 or patch.ident == 0x20007)) or \
-               (isGreaterOrEqVersion(ver,  8,6,0,0) and (patch.ident == 0xffffffff)):  # noqa: E231
+            if (LV.isGreaterOrEqVersion(ver, 10,0,0,0) and (patch.ident == 0x20000 or patch.ident == 0x20007)) or \
+               (LV.isGreaterOrEqVersion(ver,  8,6,0,0) and (patch.ident == 0xffffffff)):  # noqa: E231
                 patch.field2 = int.from_bytes(bldata.read(4), byteorder=archEndianness, signed=False)
                 self.appendPrintMapEntry(section, bldata.tell(), 4, 1, "Patch[{}].Field2".format(pidx))
                 bucketCount = int.from_bytes(bldata.read(2), byteorder=archEndianness, signed=False)
@@ -6492,7 +6493,7 @@ class VICD(CompleteBlock):
                 uneven_len = patchLen % 4  # Read padding
                 if uneven_len > 0:
                     bldata.read(4 - uneven_len)
-            elif isGreaterOrEqVersion(ver, 6,0,0,0) and (patch.ident == 0xffffffff):  # noqa: E231
+            elif LV.isGreaterOrEqVersion(ver, 6,0,0,0) and (patch.ident == 0xffffffff):  # noqa: E231
                 raise NotImplementedError("No XML export made for LV6 relocations")
             else:
                 pass
@@ -6519,8 +6520,8 @@ class VICD(CompleteBlock):
         for patch in section.patches:
             data_buf += int(patch.offs).to_bytes(4, byteorder=archEndianness, signed=False)
             data_buf += int(patch.ident).to_bytes(4, byteorder=archEndianness, signed=False)
-            if (isGreaterOrEqVersion(ver, 10,0,0,0) and (patch.ident == 0x20000 or patch.ident == 0x20007)) or \
-               (isGreaterOrEqVersion(ver,  8,6,0,0) and (patch.ident == 0xffffffff)):  # noqa: E231
+            if (LV.isGreaterOrEqVersion(ver, 10,0,0,0) and (patch.ident == 0x20000 or patch.ident == 0x20007)) or \
+               (LV.isGreaterOrEqVersion(ver,  8,6,0,0) and (patch.ident == 0xffffffff)):  # noqa: E231
                 data_buf += int(patch.field2).to_bytes(4, byteorder=archEndianness, signed=False)
                 relocs = patch.relocs  # no sorted() - preserve original order
                 bucket_idx = 0
@@ -6541,7 +6542,7 @@ class VICD(CompleteBlock):
                     bucket_idx += 1
                 data_buf += int(bucket_idx).to_bytes(2, byteorder=archEndianness, signed=False)
                 data_buf += bucket_buf
-            elif isGreaterOrEqVersion(ver, 6,0,0,0) and (patch.ident == 0xffffffff):  # noqa: E231
+            elif LV.isGreaterOrEqVersion(ver, 6,0,0,0) and (patch.ident == 0xffffffff):  # noqa: E231
                 raise NotImplementedError("No bin prepare made for LV6 relocations")
 
         patchesTotLen = section.codeEndOffset - section.pTabOffset
@@ -6633,8 +6634,8 @@ class VICD(CompleteBlock):
                 import sys
                 import traceback
                 traceback.print_exc(file=sys.stdout)
-            eprint("{:s}: Warning: Block {} section {} patches parse exception: {}."
-                   .format(self.vi.src_fname, self.ident, section_num, str(e)))
+            LV.eprint("{:s}: Warning: Block {} section {} patches parse exception: {}."
+                      .format(self.vi.src_fname, self.ident, section_num, str(e)))
             self.parseRSRCSectionRawPatches(section, section_num, patchesPos, archEndianness, archDependLen, bldata)
         self.appendPrintMapEntry(section, bldata.tell(), bldata.tell() - patchesPos, 1, "Patches")
 
@@ -6820,15 +6821,15 @@ class VICD(CompleteBlock):
         ver = self.vi.getFileVersion()
         subelem = ET.SubElement(section_elem, "General")
 
-        subelem.set("CodeID", getPrettyStrFromRsrcType(section.codeID))
+        subelem.set("CodeID", LV.getPrettyStrFromRsrcType(section.codeID))
         subelem.set("CodeFlags", "0x{:X}".format(section.codeFlags))
         subelem.set("Version", "0x{:X}".format(section.version))
         subelem.set("CompilerOptimizationLevel", "{:d}".format(section.compilerOptimizationLevel))
-        if isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231
-            subelem.set("Verifier", getPrettyStrFromRsrcType(section.verifier))
+        if LV.isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231
+            subelem.set("Verifier", LV.getPrettyStrFromRsrcType(section.verifier))
 
-        if isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231
-            subelem.set("EndVerifier", getPrettyStrFromRsrcType(section.endVerifier))
+        if LV.isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231
+            subelem.set("EndVerifier", LV.getPrettyStrFromRsrcType(section.endVerifier))
             subelem.set("EndProp1", "{:d}".format(section.endProp1))
             subelem.set("EndSignatureName", "{:d}".format(section.endSignatureName))
             subelem.set("EndLocalLVRTCodeBlocks", "{:d}".format(section.endLocalLVRTCodeBlocks))
@@ -6845,7 +6846,7 @@ class VICD(CompleteBlock):
                 pass  # Items parsed somewhere else
             elif (subelem.tag == "General"):
                 tmp = subelem.get("CodeID")
-                section.codeID = getRsrcTypeFromPrettyStr(tmp)
+                section.codeID = LV.getRsrcTypeFromPrettyStr(tmp)
                 tmp = subelem.get("CodeFlags")
                 section.codeFlags = int(tmp, 0)
                 tmp = subelem.get("Version")
@@ -6854,11 +6855,11 @@ class VICD(CompleteBlock):
                 section.compilerOptimizationLevel = int(tmp, 0)
                 tmp = subelem.get("Verifier")
                 if tmp is not None:
-                    section.verifier = getRsrcTypeFromPrettyStr(tmp)
+                    section.verifier = LV.getRsrcTypeFromPrettyStr(tmp)
 
                 tmp = subelem.get("EndVerifier")
                 if tmp is not None:
-                    section.endVerifier = getRsrcTypeFromPrettyStr(tmp)
+                    section.endVerifier = LV.getRsrcTypeFromPrettyStr(tmp)
                 tmp = subelem.get("EndProp1")
                 if tmp is not None:
                     section.endProp1 = int(tmp, 0)
@@ -6956,29 +6957,29 @@ class VICD(CompleteBlock):
         ret = True
         if section.initProcOffset >= section.pTabOffset:
             if (self.po.verbose > 1):
-                eprint("{:s}: Warning: InitProcOffset 0x{:X} exceeds PTabOffset 0x{:X}"
-                       .format(self.vi.src_fname, section.initProcOffset, section.pTabOffset))
+                LV.eprint("{:s}: Warning: InitProcOffset 0x{:X} exceeds PTabOffset 0x{:X}"
+                          .format(self.vi.src_fname, section.initProcOffset, section.pTabOffset))
             ret = False
-        if isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 5,0,0,0):  # noqa: E231
             if section.pTabOffset >= section.codeEndOffset:
                 if (self.po.verbose > 1):
-                    eprint("{:s}: Warning: PTabOffset 0x{:X} exceeds CodeEndOffset 0x{:X}"
-                           .format(self.vi.src_fname, section.pTabOffset, section.codeEndOffset))
+                    LV.eprint("{:s}: Warning: PTabOffset 0x{:X} exceeds CodeEndOffset 0x{:X}"
+                              .format(self.vi.src_fname, section.pTabOffset, section.codeEndOffset))
                 ret = False
             if section.codeEndOffset != section.endCodeEndOffset:
                 if (self.po.verbose > 1):
-                    eprint("{:s}: Warning: Copies of CodeEndOffset are different (0x{:X} and 0x{:X})"
-                           .format(self.vi.src_fname, section.codeEndOffset, section.endCodeEndOffset))
+                    LV.eprint("{:s}: Warning: Copies of CodeEndOffset are different (0x{:X} and 0x{:X})"
+                              .format(self.vi.src_fname, section.codeEndOffset, section.endCodeEndOffset))
                 ret = False
             if section.verifier not in (b'code',):
                 if (self.po.verbose > 1):
-                    eprint("{:s}: Warning: Verifier property {} is not known"
-                           .format(self.vi.src_fname, section.verifier))
+                    LV.eprint("{:s}: Warning: Verifier property {} is not known"
+                              .format(self.vi.src_fname, section.verifier))
                 ret = False
             if section.endVerifier not in (b'CODE',):
                 if (self.po.verbose > 1):
-                    eprint("{:s}: Warning: EndVerifier property {} is not known"
-                           .format(self.vi.src_fname, section.endVerifier))
+                    LV.eprint("{:s}: Warning: EndVerifier property {} is not known"
+                              .format(self.vi.src_fname, section.endVerifier))
                 ret = False
         else:  # Older versions lack many header fields
             pass
@@ -7021,7 +7022,7 @@ class VITS(CompleteBlock):
         section.endianness = 'big'
 
         # Get count of tags; endianness was wrong in some versions
-        if isGreaterOrEqVersion(ver, 6,1,0,4):  # noqa: E231
+        if LV.isGreaterOrEqVersion(ver, 6,1,0,4):  # noqa: E231
             count = int.from_bytes(bldata.read(4), byteorder=section.endianness, signed=False)
         else:
             # We can't be sure whether the enianness in this version is correct or not. We have to check that
@@ -7037,13 +7038,13 @@ class VITS(CompleteBlock):
 
         for i in range(count):
             val = SimpleNamespace()
-            val.name = readLStr(bldata, 1, self.po)
+            val.name = LV.readLStr(bldata, 1, self.po)
             self.appendPrintMapEntry(section, bldata.tell(), 4+len(val.name), 1,
                                      "TagObject[{}].Name".format(len(section.content)))
-            if isSmallerVersion(ver, 6,5,0,2):  # noqa: E231
+            if LV.isSmallerVersion(ver, 6,5,0,2):  # noqa: E231
                 bldata.read(4)
             obj_pos = bldata.tell()
-            val.obj = LVdatafill.newDataFillObject(self.vi, blockref, TD_FULL_TYPE.LVVariant, None, self.po)
+            val.obj = LVdatafill.newDataFillObject(self.vi, blockref, LVdatatype.TD_FULL_TYPE.LVVariant, None, self.po)
             val.obj.useConsolidatedTypes = False
             if val.name in (b'nirviModGen',):
                 # The content of this type is RSRC file - store it accordingly
@@ -7061,8 +7062,8 @@ class VITS(CompleteBlock):
         # Endianness was wrong in some versions
         data_buf += len(section.content).to_bytes(4, byteorder=section.endianness, signed=False)
         for val in section.content:
-            data_buf += prepareLStr(val.name, 1, self.po)
-            if isSmallerVersion(ver, 6,5,0,2):  # noqa: E231
+            data_buf += LV.prepareLStr(val.name, 1, self.po)
+            if LV.isSmallerVersion(ver, 6,5,0,2):  # noqa: E231
                 data_buf += (b'\0' * 4)
             data_buf += val.obj.prepareRSRCData()
         return data_buf

--- a/pylabview/LVblock.py
+++ b/pylabview/LVblock.py
@@ -3573,7 +3573,7 @@ class LVSR(CompleteBlock):
     def parseRSRCSectionData(self, section_num, bldata):
         section = self.sections[section_num]
 
-        # Size of the data increses with further versions
+        # Size of the data increases with further versions
         # Data before byte 68 does not move - so it's always safe to read
         data = LVinstrument.LVSRData(self.po)
         dataLen = bldata.readinto(data)
@@ -5339,7 +5339,6 @@ class HeapVerc(CompleteBlock):
         content_len = int.from_bytes(bldata.read(4), byteorder='big', signed=False)
         container_start = bldata.tell()
 
-        '''
         # TODO disabled as parsing HeapVerc is not fully implemented
         bldata.seek(content_len)
         data_len = int.from_bytes(bldata.read(4), byteorder='big', signed=False)
@@ -5348,9 +5347,8 @@ class HeapVerc(CompleteBlock):
         container_len = content_len - data_len - container_start  # noqa F841  # see TODO below
 
         raw_subdata = bldata.read(data_len)
-        blsubdata = io.BytesIO(raw_subdata)
+        blsubdata = io.BytesIO(raw_subdata)  # noqa F841  # may not be needed, see TODO below
         bldata.seek(container_start)
-        '''
 
         section.objects = []
         # TODO parse heap data

--- a/pylabview/LVblock.py
+++ b/pylabview/LVblock.py
@@ -21,7 +21,7 @@ import zlib
 from PIL import Image
 from hashlib import md5
 from types import SimpleNamespace
-from ctypes import *
+from ctypes import c_ubyte, c_uint32, c_int32, sizeof
 
 import pylabview.LVmisc as LV
 import pylabview.LVxml as ET
@@ -391,7 +391,7 @@ class Block(object):
         self.size = expSize
         if (self.po.verbose > 1):
             print("{:s}: Block {} max data size set to {:d} bytes".format(self.vi.src_fname, self.ident, self.size))
-        return minSize
+        return expSize
 
     def readRawDataSections(self, section_count=None):
         """ Reads raw data of sections from input file, up to given number
@@ -428,7 +428,7 @@ class Block(object):
             # It seem to be always the case, though file format does not mandate that
             if section.start.data_offset + sizeof(BlockSectionData) > rsrc_data_size:
                 raise IOError("Requested {} section {:d} data offset exceeds size of data block ({} > {})"
-                      .format(self.ident, i, section.start.data_offset + sizeof(BlockSectionData), rsrc_data_size))
+                      .format(self.ident, snum, section.start.data_offset + sizeof(BlockSectionData), rsrc_data_size))
             if fh.readinto(blksect) != sizeof(blksect):
                 raise EOFError("Could not read BlockSectionData struct for block {} at {:d}"
                                .format(self.ident, section.block_pos))
@@ -3342,6 +3342,10 @@ class DSTM(CompleteBlock):
     def getMaxTypeId(self, section_num=None):
         """ Returns TypeID of first item above ones mapped in this section
         """
+        if section_num is None:
+            section_num = self.active_section_num
+        self.parseData(section_num=section_num)
+        section = self.sections[section_num]
         return 1+len(section.content)
 
     def getTypeEntry(self, tme_index, section_num=None):
@@ -3830,7 +3834,8 @@ class LVSR(CompleteBlock):
 
             part_fname = "{:s}_{:s}.{:s}".format(fname_base, subelem.tag, "bin")
             if (self.po.verbose > 1):
-                print("{}: Storing block {} section {:d} part in '{}'".format(self.vi.src_fname, self.ident, snum, part_fname))
+                print("{}: Storing block {} section {:d} part in '{}'"
+                      .format(self.vi.src_fname, self.ident, section_num, part_fname))
             with open(part_fname, "wb") as part_fh:
                 part_fh.write(section.field90)
             subelem.set("Format", "bin")


### PR DESCRIPTION
- Change `from pylabview.LVxxx import *` to `import pylabview.LVxxx as LVxxx`, to avoid wildcard imports, by adding `LVxxx` module specifiers as needed
- Fix the undefined variables (that become apparent as a consequence)
- Remove unused variables (unless part of 'TODO')
